### PR TITLE
Deleted loop breakout if ADC device name was not old format

### DIFF
--- a/src/ADCSensorMain.cpp
+++ b/src/ADCSensorMain.cpp
@@ -89,10 +89,6 @@ void createSensors(
             // configuration
             for (auto& path : paths)
             {
-                if (!isAdc(path.parent_path()))
-                {
-                    continue;
-                }
                 std::smatch match;
                 std::string pathStr = path.string();
 


### PR DESCRIPTION
Presently there is no upstream commit for this addition.

Deleted loop breakout if ADC device name was not old format

ADCSensor was checking for old ADC device name.
If that name was not found a loop breakout occurred.
Thus ADCSensor never found the new ADC device name.

Signed-off-by: Tom Ippolito <thomas.ippolito@ibm.com>