### PR TITLE
Hardcode the chassis association path

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -424,8 +424,11 @@ void createAssociation(
         std::filesystem::path p(path);
 
         std::vector<Association> associations;
-        associations.emplace_back("chassis", "all_sensors",
-                                  p.parent_path().string());
+        // Hardcode the chassis path until there is an upstream dbus-sensors
+        // way to find the appropriate chassis and not just the board.
+        associations.emplace_back(
+            "chassis", "all_sensors",
+            "/xyz/openbmc_project/inventory/system/chassis");
         association->register_property("Associations", associations);
         association->initialize();
     }


### PR DESCRIPTION
For a sensor to show up in Redfish on our systems, it must be associated
to an object path that implements the Chassis D-Bus interface.

On our systems, that chassis object is hosted by
phosphor-inventory-manager, so D-Bus sensors doesn't know about it.

For now, just hard code the chassis object path to be the one used on all
of our systems.  If this ever changes, the code may need to try to find
it somehow, though as of now there is no way to identify one chassis
versus another.

Eventually, the hope is that a) phosphor-inventory-manager will be
replaced completely by entity-manager so the chassis object will be in
entity-manager and b) upstream openbmc will also require sensors to be
on the chassis so dbus-sensors will be fixed to be able to find the
chassis in entity-manager and not just use the sensor's parent board
object.

Change-Id: I75e5db256ff2b642cf34398e8ba2d786d728f984