### PR TITLE
For/1020/nvmesensor excessive logging

### DIFF
--- a/src/NVMeBasicContext.cpp
+++ b/src/NVMeBasicContext.cpp
@@ -292,6 +292,13 @@ void NVMeBasicContext::readAndProcessNVMeSensor()
 
     std::shared_ptr<NVMeSensor>& sensor = sensors.front();
 
+    if (!sensor->readingStateGood())
+    {
+        sensor->markAvailable(false);
+        sensor->updateValue(std::numeric_limits<double>::quiet_NaN());
+        return;
+    }
+
     /* Ensure sensor query parameters are sensible */
     if (sensor->bus < 0)
     {


### PR DESCRIPTION
The drive I2C endpoints are not available in the standby power domain, so don't poll them while the chassis isn't powered.