### PR TITLE
Account for hot-unplug events with the NVMe EM configuration going away

### DIFF
--- a/include/NVMeContext.hpp
+++ b/include/NVMeContext.hpp
@@ -24,6 +24,25 @@ class NVMeContext : public std::enable_shared_from_this<NVMeContext>
         sensors.emplace_back(sensor);
     }
 
+    std::optional<std::shared_ptr<NVMeSensor>>
+        getSensorAtPath(const std::string& path)
+    {
+        for (auto& sensor : sensors)
+        {
+            if (sensor->configurationPath == path)
+            {
+                return sensor;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    void removeSensor(std::shared_ptr<NVMeSensor> sensor)
+    {
+        sensors.remove(sensor);
+    }
+
     virtual void pollNVMeDevices()
     {}
 

--- a/include/NVMeSensor.hpp
+++ b/include/NVMeSensor.hpp
@@ -6,6 +6,9 @@
 class NVMeSensor : public Sensor
 {
   public:
+    static constexpr const char* CONFIG_TYPE =
+        "xyz.openbmc_project.Configuration.NVME1000";
+
     NVMeSensor(sdbusplus::asio::object_server& objectServer,
                boost::asio::io_service& io,
                std::shared_ptr<sdbusplus::asio::connection>& conn,

--- a/src/NVMeSensor.cpp
+++ b/src/NVMeSensor.cpp
@@ -31,8 +31,8 @@ NVMeSensor::NVMeSensor(sdbusplus::asio::object_server& objectServer,
                        const int busNumber) :
     Sensor(boost::replace_all_copy(sensorName, " ", "_"),
            std::move(thresholdsIn), sensorConfiguration,
-           "xyz.openbmc_project.Configuration.NVMe", false, maxReading,
-           minReading, conn, PowerState::on),
+           NVMeSensor::CONFIG_TYPE, false, maxReading, minReading, conn,
+           PowerState::on),
     bus(busNumber), objServer(objectServer)
 {
     sensorInterface = objectServer.add_interface(

--- a/src/NVMeSensorMain.cpp
+++ b/src/NVMeSensorMain.cpp
@@ -22,9 +22,6 @@
 
 #include <regex>
 
-static constexpr const char* sensorType =
-    "xyz.openbmc_project.Configuration.NVME1000";
-
 static NVMEMap nvmeDeviceMap;
 
 static constexpr bool debug = false;
@@ -65,7 +62,7 @@ void createSensors(boost::asio::io_service& io,
                     baseConfiguration = nullptr;
 
                 // find base configuration
-                auto sensorBase = sensor.second.find(sensorType);
+                auto sensorBase = sensor.second.find(NVMeSensor::CONFIG_TYPE);
                 if (sensorBase != sensor.second.end())
                 {
                     baseConfiguration = &(*sensorBase);
@@ -149,7 +146,7 @@ void createSensors(boost::asio::io_service& io,
                 context->pollNVMeDevices();
             }
         }));
-    getter->getConfiguration(std::vector<std::string>{sensorType});
+    getter->getConfiguration(std::vector<std::string>{NVMeSensor::CONFIG_TYPE});
 }
 
 int main()
@@ -191,7 +188,7 @@ int main()
         static_cast<sdbusplus::bus::bus&>(*systemBus),
         "type='signal',member='PropertiesChanged',path_namespace='" +
             std::string(inventoryPath) + "',arg0namespace='" +
-            std::string(sensorType) + "'",
+            std::string(NVMeSensor::CONFIG_TYPE) + "'",
         eventHandler);
 
     setupManufacturingModeMatch(*systemBus);

--- a/src/NVMeSensorMain.cpp
+++ b/src/NVMeSensorMain.cpp
@@ -149,6 +149,40 @@ void createSensors(boost::asio::io_service& io,
     getter->getConfiguration(std::vector<std::string>{NVMeSensor::CONFIG_TYPE});
 }
 
+static void interfaceRemoved(sdbusplus::message::message& message,
+                             NVMEMap& contexts)
+{
+    if (message.is_method_error())
+    {
+        std::cerr << "interfacesRemoved callback method error\n";
+        return;
+    }
+
+    sdbusplus::message::object_path path;
+    std::vector<std::string> interfaces;
+
+    message.read(path, interfaces);
+
+    for (auto& [_, context] : contexts)
+    {
+        std::optional<std::shared_ptr<NVMeSensor>> sensor =
+            context->getSensorAtPath(path);
+        if (!sensor)
+        {
+            continue;
+        }
+
+        auto interface = std::find(interfaces.begin(), interfaces.end(),
+                                   (*sensor)->objectType);
+        if (interface == interfaces.end())
+        {
+            continue;
+        }
+
+        context->removeSensor(sensor.value());
+    }
+}
+
 int main()
 {
     boost::asio::io_service io;
@@ -190,6 +224,16 @@ int main()
             std::string(inventoryPath) + "',arg0namespace='" +
             std::string(NVMeSensor::CONFIG_TYPE) + "'",
         eventHandler);
+
+    // Watch for entity-manager to remove configuration interfaces
+    // so the corresponding sensors can be removed.
+    auto ifaceRemovedMatch = std::make_unique<sdbusplus::bus::match::match>(
+        static_cast<sdbusplus::bus::bus&>(*systemBus),
+        "type='signal',member='InterfacesRemoved',arg0path='" +
+            std::string(inventoryPath) + "/'",
+        [](sdbusplus::message::message& msg) {
+            interfaceRemoved(msg, nvmeDeviceMap);
+        });
 
     setupManufacturingModeMatch(*systemBus);
     io.run();


### PR DESCRIPTION
Upstream changes:

https://gerrit.openbmc-project.xyz/q/topic:%22nvmesensor-hot-unplug%22+(status:open%20OR%20status:merged)