### PR TITLE
hwmontemp: Support for devices on slot power

### DIFF
--- a/include/SlotPowerManager.hpp
+++ b/include/SlotPowerManager.hpp
@@ -1,0 +1,90 @@
+#pragma once
+#include <Utils.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/container/flat_map.hpp>
+#include <boost/container/flat_set.hpp>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/bus/match.hpp>
+
+using SlotOnFuncType = std::function<void(
+    const std::shared_ptr<boost::container::flat_set<std::string>>&)>;
+
+static const char* powerStateInterface =
+    "xyz.openbmc_project.State.Decorator.PowerState";
+
+/**
+ * This class assists with handling sensor devices that are on the
+ * same power domain as the slot the card plugs into.
+ *
+ * It requires
+ *    "PowerStateOwner": "PCIeSlot",
+ *    "LocationCode": "<location code of slot>"
+ * in the entity-manager config to activate it for a device.
+ *
+ * public methods:
+ *   isDeviceOff()
+ *     - If the device is powered off or not based on the slot power state
+ *
+ *   update()
+ *     - Called from createSensors() to bind device drivers to their
+ *       device when they are powered on so they can be read.
+ *
+ * It also has propertiesChanged watches on the slot power states
+ * so it can call createSensors() again when slots are turned on so
+ * the sensor objects can be created.
+ */
+class SlotPowerManager
+{
+  public:
+    SlotPowerManager(boost::asio::io_service& io,
+                     std::shared_ptr<sdbusplus::asio::connection> systemBus,
+                     SlotOnFuncType slotOnFunc) :
+        io(io),
+        systemBus(systemBus),
+        match(static_cast<sdbusplus::bus::bus&>(*systemBus),
+              "type='signal',member='PropertiesChanged',path_namespace='" +
+                  std::string(inventoryPath) + "',arg0namespace='" +
+                  powerStateInterface + "'",
+              std::bind(&SlotPowerManager::powerStateChanged, this,
+                        std::placeholders::_1)),
+        slotOnFunc(slotOnFunc)
+    {}
+
+    bool isDeviceOff(uint64_t bus, uint64_t address) const;
+
+    void update(const ManagedObjectType& sensorConfigurations);
+
+  private:
+    struct DeviceInfo
+    {
+        std::string name;
+        std::string type;
+        std::string state;
+        std::string locationCode;
+        uint64_t bus;
+        uint64_t address;
+    };
+
+    void powerStateChanged(sdbusplus::message::message& msg);
+    void getDeviceConfigs(const ManagedObjectType& sensorConfigurations,
+                          std::vector<DeviceInfo>& deviceConfigs);
+    void getSlots(std::map<std::string, std::string>& slots);
+    void newDevice(const DeviceInfo& device);
+    void bindDrivers();
+    bool deviceExists(const DeviceInfo& device);
+    std::string getPowerState(const std::string& path);
+
+    boost::asio::io_service& io;
+
+    std::shared_ptr<sdbusplus::asio::connection> systemBus;
+
+    sdbusplus::bus::match::match match;
+
+    std::map<std::string, std::vector<DeviceInfo>> slotDevices;
+
+    SlotOnFuncType slotOnFunc;
+};
+
+extern std::unique_ptr<SlotPowerManager> slotPowerManager;

--- a/src/HwmonTempSensor.cpp
+++ b/src/HwmonTempSensor.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 */
 
+#include "SlotPowerManager.hpp"
+
 #include <unistd.h>
 
 #include <HwmonTempSensor.hpp>
@@ -100,7 +102,7 @@ HwmonTempSensor::~HwmonTempSensor()
 
 void HwmonTempSensor::setupRead(void)
 {
-    if (!readingStateGood())
+    if (!readingStateGood() || slotPowerManager->isDeviceOff(bus, address))
     {
         markAvailable(false);
         updateValue(std::numeric_limits<double>::quiet_NaN());

--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -5,7 +5,6 @@
 
 #include <filesystem>
 #include <fstream>
-#include <ranges>
 
 PHOSPHOR_LOG2_USING;
 namespace fs = std::filesystem;
@@ -257,7 +256,7 @@ void SlotPowerManager::powerStateChanged(sdbusplus::message::message& msg)
 
 void SlotPowerManager::bindDrivers()
 {
-    for (auto& devices : slotDevices | std::views::values)
+    for (const auto& [_, devices] : slotDevices)
     {
         for (const auto& device : devices)
         {
@@ -313,14 +312,14 @@ bool SlotPowerManager::deviceExists(const DeviceInfo& device)
 
 bool SlotPowerManager::isDeviceOff(uint64_t bus, uint64_t address) const
 {
-    for (auto& configs : slotDevices | std::views::values)
+    for (const auto& [_, devices] : slotDevices)
     {
         auto deviceIt = std::find_if(
-            configs.begin(), configs.end(), [bus, address](const auto& config) {
-                return (bus == config.bus) && (address == config.address);
+            devices.begin(), devices.end(), [bus, address](const auto& device) {
+                return (bus == device.bus) && (address == device.address);
             });
 
-        if (deviceIt != configs.end())
+        if (deviceIt != devices.end())
         {
             return boost::ends_with(deviceIt->state, "Off");
         }

--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -1,7 +1,6 @@
 #include "SlotPowerManager.hpp"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/asio/deadline_timer.hpp> //remove
 #include <phosphor-logging/lg2.hpp>
 
 #include <filesystem>
@@ -23,7 +22,6 @@ constexpr auto baseI2CPath = "/sys/bus/i2c/devices/i2c-";
 void SlotPowerManager::update(const ManagedObjectType& sensorConfigurations)
 {
     std::vector<std::string> newSlots;
-    std::map<std::string, std::string> powerStates;
     std::vector<DeviceInfo> deviceConfigs;
     static std::map<std::string, std::string> slots;
 
@@ -122,10 +120,10 @@ void SlotPowerManager::getDeviceConfigs(
             deviceInfo.address = std::get<uint64_t>(config.at("Address"));
             deviceInfo.locationCode = std::get<std::string>(locCodeIt->second);
 
-            deviceConfigs.push_back(std::move(deviceInfo));
-
             debug("DeviceInfo: Name: {NAME}, Type: {TYPE}", "NAME",
                   deviceInfo.name, "TYPE", deviceInfo.type);
+
+            deviceConfigs.push_back(std::move(deviceInfo));
         }
     }
 }

--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -257,7 +257,7 @@ void SlotPowerManager::powerStateChanged(sdbusplus::message::message& msg)
 
 void SlotPowerManager::bindDrivers()
 {
-    for (const auto& devices : slotDevices | std::views::values)
+    for (auto& devices : slotDevices | std::views::values)
     {
         for (const auto& device : devices)
         {
@@ -313,7 +313,7 @@ bool SlotPowerManager::deviceExists(const DeviceInfo& device)
 
 bool SlotPowerManager::isDeviceOff(uint64_t bus, uint64_t address) const
 {
-    for (const auto& configs : slotDevices | std::views::values)
+    for (auto& configs : slotDevices | std::views::values)
     {
         auto deviceIt = std::find_if(
             configs.begin(), configs.end(), [bus, address](const auto& config) {

--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -1,0 +1,331 @@
+#include "SlotPowerManager.hpp"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/asio/deadline_timer.hpp> //remove
+#include <phosphor-logging/lg2.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <ranges>
+
+PHOSPHOR_LOG2_USING;
+namespace fs = std::filesystem;
+
+std::unique_ptr<SlotPowerManager> slotPowerManager;
+
+static const char* locationCodeInterface =
+    "xyz.openbmc_project.Inventory.Decorator.LocationCode";
+static const char* pcieSlotInterface =
+    "xyz.openbmc_project.Inventory.Item.PCIeSlot";
+
+constexpr auto baseI2CPath = "/sys/bus/i2c/devices/i2c-";
+
+void SlotPowerManager::update(const ManagedObjectType& sensorConfigurations)
+{
+    std::vector<std::string> newSlots;
+    std::map<std::string, std::string> powerStates;
+    std::vector<DeviceInfo> deviceConfigs;
+    static std::map<std::string, std::string> slots;
+
+    // Pull the applicable device configs out of the EM D-Bus objects
+    getDeviceConfigs(sensorConfigurations, deviceConfigs);
+    if (deviceConfigs.empty())
+    {
+        return;
+    }
+
+    debug("Found {SIZE} device configs", "SIZE", deviceConfigs.size());
+
+    // Get map of locations codes to their slots
+    if (slots.empty())
+    {
+        getSlots(slots);
+    }
+
+    // Build the slotDevices map
+    for (auto& deviceInfo : deviceConfigs)
+    {
+        auto slotNameIt = slots.find(deviceInfo.locationCode);
+        if (slotNameIt == slots.end())
+        {
+            error("No slot found for sensor location code {LOC}", "LOC",
+                  deviceInfo.locationCode);
+            continue;
+        }
+
+        const auto& slotName = slotNameIt->second;
+        auto powerState = getPowerState(slotName);
+
+        auto slotDataIt = slotDevices.find(slotName);
+        if (slotDataIt == slotDevices.end())
+        {
+            debug("Initial power state of {SLOT} is {STATE}", "SLOT", slotName,
+                  "STATE", powerState);
+            deviceInfo.state = powerState;
+            slotDevices.emplace(slotName, std::vector{deviceInfo});
+            newSlots.push_back(slotName);
+        }
+        else
+        {
+            // Add another device to this slot.  As update() can get
+            // called multiple times with the same set of slots, only
+            // allow this if we added the slot for the first time in
+            // this function call.
+            if (std::find(newSlots.begin(), newSlots.end(), slotName) !=
+                newSlots.end())
+            {
+                deviceInfo.state = powerState;
+                slotDataIt->second.push_back(deviceInfo);
+            }
+        }
+    }
+
+    // Bind device drivers for devices that are present and powered on
+    bindDrivers();
+}
+
+// Find the devices on slot power
+void SlotPowerManager::getDeviceConfigs(
+    const ManagedObjectType& sensorConfigurations,
+    std::vector<DeviceInfo>& deviceConfigs)
+{
+    for (const auto& [objectPath, sensorData] : sensorConfigurations)
+    {
+        for (const auto& [type, config] : sensorData)
+        {
+            auto ownerIt = config.find("PowerStateOwner");
+            if (ownerIt == config.end())
+            {
+                continue;
+            }
+
+            const auto& owner = std::get<std::string>(ownerIt->second);
+            if (owner != "PCIeSlot")
+            {
+                std::cerr << "Invalid PowerStateOwner type: " << owner
+                          << " in entity-manager config\n";
+                continue;
+            }
+
+            auto locCodeIt = config.find("LocationCode");
+            if (locCodeIt == config.end())
+            {
+                std::cerr << "Missing LocationCode entry on " << objectPath.str
+                          << "\n";
+                continue;
+            }
+
+            DeviceInfo deviceInfo;
+            deviceInfo.name = std::get<std::string>(config.at("Name"));
+            deviceInfo.type = std::get<std::string>(config.at("Type"));
+            deviceInfo.bus = std::get<uint64_t>(config.at("Bus"));
+            deviceInfo.address = std::get<uint64_t>(config.at("Address"));
+            deviceInfo.locationCode = std::get<std::string>(locCodeIt->second);
+
+            deviceConfigs.push_back(std::move(deviceInfo));
+
+            debug("DeviceInfo: Name: {NAME}, Type: {TYPE}", "NAME",
+                  deviceInfo.name, "TYPE", deviceInfo.type);
+        }
+    }
+}
+
+// Build the locCode->slotPath map
+void SlotPowerManager::getSlots(std::map<std::string, std::string>& slots)
+{
+    auto& bus = static_cast<sdbusplus::bus::bus&>(*systemBus);
+
+    auto method = bus.new_method_call(mapper::busName, mapper::path,
+                                      mapper::interface, mapper::subtree);
+    method.append(std::string{"/"}, 0,
+                  std::vector<std::string>{pcieSlotInterface});
+    auto reply = bus.call(method);
+
+    GetSubTreeType subtree;
+    reply.read(subtree);
+
+    for (const auto& [path, objDict] : subtree)
+    {
+        const auto& busName = objDict[0].first;
+        auto method =
+            bus.new_method_call(busName.c_str(), path.c_str(),
+                                properties::interface, properties::get);
+        method.append(locationCodeInterface, "LocationCode");
+
+        try
+        {
+            auto reply = bus.call(method);
+
+            std::variant<std::string> locationCode;
+            reply.read(locationCode);
+            const auto& locCode = std::get<std::string>(locationCode);
+            slots.emplace(locCode, path);
+        }
+        catch (const sdbusplus::exception::exception& ex)
+        {
+            error("Failed getting location code from {PATH}: {EX}", "PATH",
+                  path, "EX", ex);
+        }
+    }
+}
+
+std::string SlotPowerManager::getPowerState(const std::string& path)
+{
+    auto& bus = static_cast<sdbusplus::bus::bus&>(*systemBus);
+    static GetSubTreeType subtree;
+
+    // Get the list of power state objects just once.
+    if (subtree.empty())
+    {
+        auto method = bus.new_method_call(mapper::busName, mapper::path,
+                                          mapper::interface, mapper::subtree);
+        method.append(std::string{"/"}, 0,
+                      std::vector<std::string>{powerStateInterface});
+        auto reply = bus.call(method);
+        reply.read(subtree);
+    }
+
+    auto entryIt = std::find_if(subtree.begin(), subtree.end(),
+                                [path](const auto& subtreeEntry) {
+                                    return path == subtreeEntry.first;
+                                });
+    if (entryIt == subtree.end())
+    {
+        throw std::runtime_error("No power state interface on " + path);
+    }
+
+    const auto& services = entryIt->second;
+
+    auto method = bus.new_method_call(services[0].first.c_str(), path.c_str(),
+                                      properties::interface, properties::get);
+    method.append(powerStateInterface, "PowerState");
+
+    auto reply = bus.call(method);
+
+    std::variant<std::string> powerState;
+    reply.read(powerState);
+
+    return std::get<std::string>(powerState);
+}
+
+void SlotPowerManager::powerStateChanged(sdbusplus::message::message& msg)
+{
+    std::string objectPath = msg.get_path();
+    std::string interface;
+    std::map<std::string, std::variant<std::string>> properties;
+
+    msg.read(interface, properties);
+
+    auto propIt = properties.find("PowerState");
+    if (propIt == properties.end())
+    {
+        return;
+    }
+
+    if (!slotDevices.contains(objectPath))
+    {
+        // Don't care about this slot
+        return;
+    }
+
+    debug("Power state of {PATH} changed to {STATE}", "PATH", objectPath,
+          "STATE", std::get<std::string>(propIt->second));
+
+    const auto& powerState = std::get<std::string>(propIt->second);
+
+    // Update the state inside the config data.
+    auto& deviceConfigs = slotDevices.at(objectPath);
+    std::for_each(
+        deviceConfigs.begin(), deviceConfigs.end(),
+        [powerState, this](auto& config) { config.state = powerState; });
+
+    // Call slotOnFunc with the name of the sensor that changed
+    if (boost::ends_with(powerState, "On") && slotOnFunc)
+    {
+        auto sensors =
+            std::make_shared<boost::container::flat_set<std::string>>();
+
+        std::for_each(deviceConfigs.begin(), deviceConfigs.end(),
+                      [&sensors](const auto& config) {
+                          // createSensors() doesn't want spaces
+                          auto name =
+                              boost::replace_all_copy(config.name, " ", "_");
+                          sensors->insert(name);
+                      });
+        // Call createSensors() (which calls update())
+        slotOnFunc(sensors);
+    }
+}
+
+void SlotPowerManager::bindDrivers()
+{
+    for (const auto& devices : slotDevices | std::views::values)
+    {
+        for (const auto& device : devices)
+        {
+            if (boost::ends_with(device.state, "On"))
+            {
+                newDevice(device);
+            }
+        }
+    }
+}
+
+void SlotPowerManager::newDevice(const DeviceInfo& device)
+{
+    if (deviceExists(device))
+    {
+        return;
+    }
+
+    std::string driverFile =
+        baseI2CPath + std::to_string(device.bus) + "/new_device";
+
+    std::ostringstream typeAddr; // e.g. "tmp435 0x4c"
+    auto type = boost::algorithm::to_lower_copy(device.type);
+    typeAddr << type << " 0x" << std::hex << device.address;
+
+    std::ofstream file{driverFile};
+    if (!file)
+    {
+        error("Could not open {FILE}", "FILE", driverFile);
+        return;
+    }
+
+    file << typeAddr.str();
+    if (file.bad() || file.fail())
+    {
+        auto e = errno;
+        error("Error writing {DATA} to {FILE}, errno {ERRNO}", "DATA",
+              typeAddr.str(), "FILE", driverFile, "ERRNO", e);
+    }
+}
+
+bool SlotPowerManager::deviceExists(const DeviceInfo& device)
+{
+    std::ostringstream deviceFile;
+
+    // e.g. /sys/bus/i2c/devices/i2c-29/29-004c
+    deviceFile << baseI2CPath << device.bus << "/" << device.bus << "-"
+               << std::setfill('0') << std::setw(4) << std::hex
+               << device.address;
+
+    return fs::exists(deviceFile.str());
+}
+
+bool SlotPowerManager::isDeviceOff(uint64_t bus, uint64_t address) const
+{
+    for (const auto& configs : slotDevices | std::views::values)
+    {
+        auto deviceIt = std::find_if(
+            configs.begin(), configs.end(), [bus, address](const auto& config) {
+                return (bus == config.bus) && (address == config.address);
+            });
+
+        if (deviceIt != configs.end())
+        {
+            return boost::ends_with(deviceIt->state, "Off");
+        }
+    }
+    return false;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -77,6 +77,7 @@ if get_option('hwmon-temp').enabled()
         'hwmontempsensor',
         'HwmonTempMain.cpp',
         'HwmonTempSensor.cpp',
+        'SlotPowerManager.cpp',
         dependencies: [
             default_deps,
             thresholds_dep,


### PR DESCRIPTION
There are a few models of IBM PCIe cards that have TMP435 temperature
sensors which are on a power domain controlled by the host and tracked
by the xyz.openbmc_project.State.Decorator.PowerState interface on the
corresponding PCIe slot D-Bus objects.  The devices won't have power
until some point after the host has been started, so the devices can't
even be detected until that point.

This commit adds support for that by creating a minimally invasive
SlotPowerManager class to watch for when the slots are turned on.  At
that point it will call the 'new_device' I2C driver interface to bind
the device driver so the hwmon instance is created, and call the
createSensors() function in HwmonTempMain.cpp so the appropriate sensor
D-Bus objects can then be created.

When the system is powered off, the driver will be left bound but the
HwmonTempSensor class will ask SlotPowerManager if the device is off so
it will just display NaN until the slot powers on again without
attempting any reads.  On subsequent boots the code will see the driver
has already been bound so it won't do it again.

To indicate to SlotPowerManager a device is on slot power it needs

"PowerStateOwner": "PCIeSlot",
"LocationCode": "<location code of slot>"

in the entity-manager D-Bus config.

This is a downstream only commit.  In the future when IBM moves to a pure entity-manager inventory config we can revisit seeing how to do this upstream, since now it needs the SlotPowerState and LocationCode properties to be provided by phosphor-inventory-manager.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: If88673f631de838a97884be1df7d5146c3c40d3e