### PR TITLE
hwmontemp: Handle missing device links

### DIFF
--- a/src/HwmonTempMain.cpp
+++ b/src/HwmonTempMain.cpp
@@ -208,7 +208,16 @@ void createSensors(
                 else
                 {
                     device = directory / "device";
-                    deviceName = fs::canonical(device).stem();
+
+                    try
+                    {
+                        deviceName = fs::canonical(device).stem();
+                    }
+                    catch (fs::filesystem_error& e)
+                    {
+                        std::cerr << device << " not available\n";
+                        continue;
+                    }
                 }
                 auto findHyphen = deviceName.find('-');
                 if (findHyphen == std::string::npos)


### PR DESCRIPTION
There is a small window of time when the BMC starts up that a device
driver may have created its directory in /sys/class/hwmon but not made
the 'device' link in it yet.  If this were to happen while
hwmontempsensor was traversing those directories, it would crash when it
calls std::filesystem::canonical() on that link and it isn't there.

Fix that by just catching the filesystem_error exception that is thrown
and continuing on.  There is a separate OCC app that handles the OCC
hwmon sensors so hwmontempsensor wouldn't do anything with them anyway.

Here's an example where the OCC driver is still doing things while
hwmontempsensor is searching the directories:

Jan 05 18:50:46 hwmontempsensor[464]: terminate called after throwing
                an instance of 'std::filesystem::__cxx11::filesystem_error'
Jan 05 18:50:46 hwmontempsensor[464]:   what():  filesystem error: cannot
                make canonical path: No such file or directory
                [/sys/class/hwmon/hwmon13/device]
Jan 05 18:50:46 kernel: occ-hwmon occ-hwmon.1: OCC found,
Jan 05 18:50:46 kernel: occ-hwmon occ-hwmon.2: OCC found,
Jan 05 18:50:47 kernel: occ-hwmon occ-hwmon.3: OCC found,
Jan 05 18:50:47 kernel: occ-hwmon occ-hwmon.4: OCC found,

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: If3d9c0308fd74c2beb5bf3d6afdc117bde2b2b98