### PR TITLE
hwmontemp: Change check for a powered off slot

### DIFF
--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -321,7 +321,7 @@ bool SlotPowerManager::isDeviceOff(uint64_t bus, uint64_t address) const
 
         if (deviceIt != devices.end())
         {
-            return boost::ends_with(deviceIt->state, "Off");
+            return !boost::ends_with(deviceIt->state, "On");
         }
     }
     return false;


### PR DESCRIPTION
The slot power state property can have three values - off, on, unknown.
Change the check for a powered off device to 'not on' so that the value of
unknown is now considered off instead of on.

Theoretically we shouldn't get into a scenario where a device is bound
but set to unknown while the power was really off, but in testing it
turned up we'd report an error if it did happen.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I823d8336be9eed82d1f6369e4f8c6158efabc11a