### PR TITLE
hwmontempsensor: Use isPowerOn() in isDeviceOff()

### DIFF
--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -60,6 +60,7 @@ bool findFiles(const std::filesystem::path& dirPath,
                int symlinkDepth = 1);
 bool isPowerOn(void);
 bool hasBiosPost(void);
+bool isPGoodOn();
 void setupPowerMatch(const std::shared_ptr<sdbusplus::asio::connection>& conn);
 bool getSensorConfiguration(
     const std::string& type,
@@ -125,6 +126,14 @@ namespace association
 const static constexpr char* interface =
     "xyz.openbmc_project.Association.Definitions";
 } // namespace association
+
+namespace pgood
+{
+const static constexpr char* busname = "org.openbmc.control.Power";
+const static constexpr char* interface = "org.openbmc.control.Power";
+const static constexpr char* path = "/org/openbmc/control/power0";
+const static constexpr char* property = "pgood";
+} // namespace pgood
 
 template <typename T>
 inline T loadVariant(

--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -321,7 +321,7 @@ bool SlotPowerManager::isDeviceOff(uint64_t bus, uint64_t address) const
 
         if (deviceIt != devices.end())
         {
-            return boost::ends_with(deviceIt->state, "Off");
+            return boost::ends_with(deviceIt->state, "Off") || !isPowerOn();
         }
     }
     return false;


### PR DESCRIPTION
The temp sensors on PCIe slot power, such as the TMP435s on the Flett
and Bear River cards, can only be accessed when the slot is powered on.
This was being checked for by reading the slot power state property.

However, there are cases where that property doesn't react fast enough
to power offs, such as when a PGood fault brings down the system.  This
would lead to a read failure error log on those sensors because the code
still thought the power was on.

To fix this, also add a check to see if system power is off when
checking to see if device on slot power is off, and then check the PGood
property inside the isPowerOn() function as well as the chassis power
state.  That function is also checked before creating an error log, so
it will also prevent errors from being logged when the PGood is off but
the status hasn't been reflected in the chassis power state yet.

It may be possible to change the isPowerOn() on from 'pgood on and power
state on' to just 'pgood on'.  That would open up a bit of window when
PGood is on before the power state gets set to on that error logs could
now be created.  That doesn't seem like a big deal, but I'm going to err
on the side of caution for now and not mess with it.

Fixes SW545876.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I751c5203dc6095e02ec1f0c4c1654551397686af