### PR TITLE
NVMeBasicContext: Fix response vector size

### DIFF
--- a/src/NVMeBasicContext.cpp
+++ b/src/NVMeBasicContext.cpp
@@ -89,7 +89,7 @@ static ssize_t execBasicQuery(int bus, uint8_t addr, uint8_t cmd,
         goto cleanup_fds;
     }
 
-    resp.reserve(UINT8_MAX + 1);
+    resp.resize(UINT8_MAX + 1);
 
     /* Issue the NVMe MI basic command */
     size = i2c_smbus_read_block_data(dev, cmd, resp.data());
@@ -110,6 +110,7 @@ static ssize_t execBasicQuery(int bus, uint8_t addr, uint8_t cmd,
         goto cleanup_fds;
     }
 
+    resp.resize(size);
     rc = size;
 
 cleanup_fds:


### PR DESCRIPTION
It was found that for some people (me!?) temperatures were reported
seemingly accurately despite the response vector never being resized to
expose the data written to its backing store by the SMBus block read.
For others[1] the response could not be parsed because the vector had
zero length. It's unclear how the code as it stood ever yielded valid
values, but here we are.

[1] https://github.com/openbmc/dbus-sensors/issues/18

Fixes: #18
Signed-off-by: Andrew Jeffery <andrew@aj.id.au>
Change-Id: Ic2015a776389635765972084de75e33e7ea23d53