### PR TITLE
nvmesensor: Add inventory associations

### DIFF
--- a/include/NVMeSensor.hpp
+++ b/include/NVMeSensor.hpp
@@ -19,6 +19,8 @@ class NVMeSensor : public Sensor
 
     NVMeSensor& operator=(const NVMeSensor& other) = delete;
 
+    void createAssociation() override;
+
     bool sample();
 
     int bus;

--- a/include/sensor.hpp
+++ b/include/sensor.hpp
@@ -218,6 +218,11 @@ struct Sensor
         return 1;
     }
 
+    virtual void createAssociation()
+    {
+        ::createAssociation(association, configurationPath);
+    }
+
     void
         setInitialProperties(std::shared_ptr<sdbusplus::asio::connection>& conn,
                              const std::string& unit,
@@ -226,7 +231,7 @@ struct Sensor
     {
         setupPowerMatch(conn);
 
-        createAssociation(association, configurationPath);
+        createAssociation();
 
         sensorInterface->register_property("Unit", unit);
         sensorInterface->register_property("MaxValue", maxValue);

--- a/src/NVMeSensor.cpp
+++ b/src/NVMeSensor.cpp
@@ -16,6 +16,7 @@
 
 #include <NVMeSensor.hpp>
 
+#include <filesystem>
 #include <iostream>
 
 static constexpr double maxReading = 127;
@@ -68,6 +69,54 @@ NVMeSensor::~NVMeSensor()
     objServer.remove_interface(thresholdInterfaceCritical);
     objServer.remove_interface(sensorInterface);
     objServer.remove_interface(association);
+}
+
+void NVMeSensor::createAssociation()
+{
+    std::filesystem::path p(configurationPath);
+    dbusConnection->async_method_call(
+        [association = association,
+         configurationPath = this->configurationPath](
+            const boost::system::error_code ec,
+            const std::variant<std::vector<Association>>& envelope) {
+            if (ec == boost::asio::error::operation_aborted)
+            {
+                return;
+            }
+
+            if (ec)
+            {
+                std::cerr << "Error getting inventory association for "
+                          << configurationPath << ": " << ec.message() << "\n";
+                return;
+            }
+
+            std::vector<Association> sensorAssociations = {
+                {
+                    "chassis",
+                    "all_sensors",
+                    "/xyz/openbmc_project/inventory/system/chassis",
+                },
+            };
+
+            auto configAssociations =
+                std::get<std::vector<Association>>(envelope);
+            for (const auto& entry : configAssociations)
+            {
+                if (std::get<0>(entry) == "probed_by")
+                {
+                    const auto& invPath = std::get<2>(entry);
+                    sensorAssociations.emplace_back("inventory", "sensors",
+                                                    invPath);
+                }
+            }
+
+            association->register_property("Associations", sensorAssociations);
+            association->initialize();
+        },
+        entityManagerName, p.parent_path().string(),
+        "org.freedesktop.DBus.Properties", "Get", association::interface,
+        "Associations");
 }
 
 bool NVMeSensor::sample()


### PR DESCRIPTION
Exploit the (probed_by, probes, ...) association that EM publishes on
its root configuration objects to associate sensors with inventory
objects in PIM.

Signed-off-by: Andrew Jeffery <andrew@aj.id.au>
Change-Id: I49c928be5e1ca2f6cc4cdc158883cc9b50bdb82b