### PR TITLE
hwmontempsensor: slot powered sensors: Check for valid Bus/Address fields

### DIFF
--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -99,16 +99,32 @@ void SlotPowerManager::getDeviceConfigs(
             const auto& owner = std::get<std::string>(ownerIt->second);
             if (owner != "PCIeSlot")
             {
-                std::cerr << "Invalid PowerStateOwner type: " << owner
-                          << " in entity-manager config\n";
+                error("Invalid PowerStateOwner type: {OWNER} in entity-manager "
+                      "config",
+                      "OWNER", owner);
                 continue;
             }
 
             auto locCodeIt = config.find("LocationCode");
             if (locCodeIt == config.end())
             {
-                std::cerr << "Missing LocationCode entry on " << objectPath.str
-                          << "\n";
+                error("Missing LocationCode entry on {PATH}", "PATH",
+                      objectPath.str);
+                continue;
+            }
+
+            if (!config.contains("Bus") || !config.contains("Address"))
+            {
+                error("Missing Bus or Address for {PATH}", "PATH",
+                      objectPath.str);
+                continue;
+            }
+
+            if (!std::get_if<uint64_t>(&config.at("Bus")) ||
+                !std::get_if<uint64_t>(&config.at("Address")))
+            {
+                error("Invalid Bus or Address for {PATH}", "PATH",
+                      objectPath.str);
                 continue;
             }
 

--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -337,7 +337,7 @@ bool SlotPowerManager::isDeviceOff(uint64_t bus, uint64_t address) const
 
         if (deviceIt != devices.end())
         {
-            return boost::ends_with(deviceIt->state, "Off") || !isPowerOn();
+            return !boost::ends_with(deviceIt->state, "On") || !isPowerOn();
         }
     }
     return false;


### PR DESCRIPTION
The code that handles sensors on PCIe slot power should validate that the Bus/Address D-Bus fields are valid uint64_t values before trying to get them, because if a card is plugged in an unsupported slot those values will be strings, like "$bus" or "$address".

The other commit fixes something noticed in some testing.

Fix for SW556218