### PR TITLE
nvmesensor: Add inventory associations (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ detection (x86) are also supported.
 
 ## key features
 
--   runtime re-configurable from d-bus (entity-manager or the like)
+- runtime re-configurable from d-bus (entity-manager or the like)
 
--   isolated: each sensor type is isolated into its own daemon, so a bug in one
-    sensor is unlikely to affect another, and single sensor modifications are
-    possible
+- isolated: each sensor type is isolated into its own daemon, so a bug in one
+  sensor is unlikely to affect another, and single sensor modifications are
+  possible
 
--   async single-threaded: uses sdbusplus/asio bindings
+- async single-threaded: uses sdbusplus/asio bindings
 
--   multiple data inputs: hwmon, d-bus, direct driver access
+- multiple data inputs: hwmon, d-bus, direct driver access
 
 ## dbus interfaces
 
@@ -33,26 +33,38 @@ Interfaces  xyz.openbmc_project.Sensor.Value
             xyz.openbmc_project.Association.Definitions
 
 ```
-Sensor interfaces collection are described [here](https://github.com/openbmc/phosphor-dbus-interfaces/tree/master/yaml/xyz/openbmc_project/Sensor).
 
-Consumer examples of these interfaces are [Redfish](https://github.com/openbmc/bmcweb/blob/master/redfish-core/lib/sensors.hpp), [Phosphor-Pid-Control](https://github.com/openbmc/phosphor-pid-control), [IPMI SDR](https://github.com/openbmc/phosphor-host-ipmid/blob/master/dbus-sdr/sensorcommands.cpp).
+Sensor interfaces collection are described
+[here](https://github.com/openbmc/phosphor-dbus-interfaces/tree/master/yaml/xyz/openbmc_project/Sensor).
+
+Consumer examples of these interfaces are
+[Redfish](https://github.com/openbmc/bmcweb/blob/master/redfish-core/lib/sensors.hpp),
+[Phosphor-Pid-Control](https://github.com/openbmc/phosphor-pid-control),
+[IPMI SDR](https://github.com/openbmc/phosphor-host-ipmid/blob/master/dbus-sdr/sensorcommands.cpp).
+
 ## Reactor
+
 dbus-sensor daemons are [reactors](https://github.com/openbmc/entity-manager)
-that dynamically create and update sensors configuration when
-system configuration gets updated.
+that dynamically create and update sensors configuration when system
+configuration gets updated.
 
-Using asio timers and async calls, dbus-sensor daemons read sensor values and check thresholds periodically.
-PropertiesChanged signals will be broadcasted for other services to consume when
-value or threshold status change.
-OperationStatus is set to false if the sensor is determined to be faulty.
+Using asio timers and async calls, dbus-sensor daemons read sensor values and
+check thresholds periodically. PropertiesChanged signals will be broadcasted for
+other services to consume when value or threshold status change. OperationStatus
+is set to false if the sensor is determined to be faulty.
 
-A simple sensor example can be found [here](https://github.com/openbmc/entity-manager/blob/master/docs/my_first_sensors.md).
+A simple sensor example can be found
+[here](https://github.com/openbmc/entity-manager/blob/master/docs/my_first_sensors.md).
 
 ## configuration
-Sensor devices are described using Exposes records in configuration file.
-Name and Type fields are required. Different sensor types have different fields.
-Refer to entity manager [schema](https://github.com/openbmc/entity-manager/blob/master/schemas/legacy.json) for complete list.
+
+Sensor devices are described using Exposes records in configuration file. Name
+and Type fields are required. Different sensor types have different fields.
+Refer to entity manager
+[schema](https://github.com/openbmc/entity-manager/blob/master/schemas/legacy.json)
+for complete list.
+
 ## sensor documentation
 
--   [ExternalSensor](https://github.com/openbmc/docs/blob/master/designs/external-sensor.md)
-    virtual sensor
+- [ExternalSensor](https://github.com/openbmc/docs/blob/master/designs/external-sensor.md)
+  virtual sensor

--- a/include/NVMeSensor.hpp
+++ b/include/NVMeSensor.hpp
@@ -18,6 +18,8 @@ class NVMeSensor : public Sensor
 
     NVMeSensor& operator=(const NVMeSensor& other) = delete;
 
+    void createAssociation() override;
+
     bool sample();
 
     int bus;

--- a/include/sensor.hpp
+++ b/include/sensor.hpp
@@ -477,11 +477,6 @@ struct Sensor
         return errCount >= errorThreshold;
     }
 
-    bool inError()
-    {
-        return errCount >= errorThreshold;
-    }
-
     void updateValue(const double& newValue)
     {
         // Ignore if overriding is enabled

--- a/include/sensor.hpp
+++ b/include/sensor.hpp
@@ -248,6 +248,11 @@ struct Sensor
         return 1;
     }
 
+    virtual void createAssociation()
+    {
+        ::createAssociation(association, configurationPath);
+    }
+
     void setInitialProperties(const std::string& unit,
                               const std::string& label = std::string(),
                               size_t thresholdSize = 0)
@@ -258,7 +263,7 @@ struct Sensor
             setupPowerMatch(dbusConnection);
         }
 
-        createAssociation(association, configurationPath);
+        createAssociation();
 
         sensorInterface->register_property("Unit", unit);
         sensorInterface->register_property("MaxValue", maxValue);

--- a/src/NVMeSensorMain.cpp
+++ b/src/NVMeSensorMain.cpp
@@ -232,7 +232,7 @@ int main()
     auto systemBus = std::make_shared<sdbusplus::asio::connection>(io);
     systemBus->request_name("xyz.openbmc_project.NVMeSensor");
     sdbusplus::asio::object_server objectServer(systemBus, true);
-    objectServer.add_manager("/xyz/openbmc_project/sensors/");
+    objectServer.add_manager("/xyz/openbmc_project/sensors");
 
     io.post([&]() { createSensors(io, objectServer, systemBus); });
 


### PR DESCRIPTION
Exploit the (probed_by, probes, ...) association that EM publishes on its root configuration objects to associate sensors with inventory objects in PIM.

Signed-off-by: Andrew Jeffery <andrew@aj.id.au>
Change-Id: I49c928be5e1ca2f6cc4cdc158883cc9b50bdb82b