### PR TITLE
Pull my changes for TMP435s on Fletts and Cable Cards into 1050

### DIFF
--- a/include/HwmonTempSensor.hpp
+++ b/include/HwmonTempSensor.hpp
@@ -32,7 +32,8 @@ class HwmonTempSensor :
                     const struct SensorParams& thisSensorParameters,
                     float pollRate, const std::string& sensorConfiguration,
                     PowerState powerState,
-                    const std::shared_ptr<I2CDevice>& i2cDevice);
+                    const std::shared_ptr<I2CDevice>& i2cDevice, size_t bus,
+                    size_t address);
     ~HwmonTempSensor() override;
     void setupRead(void);
     void activate(const std::string& newPath,
@@ -57,6 +58,8 @@ class HwmonTempSensor :
     double offsetValue;
     double scaleValue;
     unsigned int sensorPollMs;
+    size_t bus;
+    size_t address;
 
     void handleResponse(const boost::system::error_code& err, size_t bytesRead);
     void restartRead();

--- a/include/HwmonTempSensor.hpp
+++ b/include/HwmonTempSensor.hpp
@@ -40,6 +40,11 @@ class HwmonTempSensor :
     void deactivate(void);
     bool isActive(void);
 
+    std::shared_ptr<I2CDevice> getI2CDevice() const
+    {
+        return i2cDevice;
+    }
+
   private:
     // Ordering is important here; readBuf is first so that it's not destroyed
     // while async operations from other member fields might still be using it.

--- a/include/HwmonTempSensor.hpp
+++ b/include/HwmonTempSensor.hpp
@@ -46,6 +46,12 @@ class HwmonTempSensor :
         return i2cDevice;
     }
 
+    // Clears the history of failed reads
+    static void clearFailedDevices();
+
+    // Create an event log for a failed read
+    void createEventLog();
+
   private:
     // Ordering is important here; readBuf is first so that it's not destroyed
     // while async operations from other member fields might still be using it.
@@ -60,6 +66,12 @@ class HwmonTempSensor :
     unsigned int sensorPollMs;
     size_t bus;
     size_t address;
+
+    // pair<bus, address> of devices with logged failed reads
+    static std::vector<std::pair<size_t, size_t>> failedDevices;
+
+    // The error code from the last HW access for the sensor.
+    boost::system::error_code errorCode;
 
     void handleResponse(const boost::system::error_code& err, size_t bytesRead);
     void restartRead();

--- a/include/SlotPowerManager.hpp
+++ b/include/SlotPowerManager.hpp
@@ -1,0 +1,83 @@
+#pragma once
+#include <Utils.hpp>
+#include <boost/container/flat_map.hpp>
+#include <boost/container/flat_set.hpp>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/bus/match.hpp>
+
+using SlotOnFuncType = std::function<void(
+    const std::shared_ptr<boost::container::flat_set<std::string>>&)>;
+
+static const char* powerStateInterface =
+    "xyz.openbmc_project.State.Decorator.PowerState";
+
+/**
+ * This class assists with handling sensor devices that are on the
+ * same power domain as the slot the card plugs into.
+ *
+ * It requires
+ *    "PowerStateOwner": "PCIeSlot",
+ *    "LocationCode": "<location code of slot>"
+ * in the entity-manager config to activate it for a device.
+ *
+ * public methods:
+ *   isDeviceOff()
+ *     - If the device is powered off or not based on the slot power state
+ *
+ *   update()
+ *     - Called from createSensors() to refresh the slot power status
+ *       so devices can be read if they are powered on.
+ *
+ * It also has propertiesChanged watches on the slot power states
+ * so it can call createSensors() again when slots are turned on so
+ * the sensor objects can be created.
+ */
+class SlotPowerManager
+{
+  public:
+    SlotPowerManager(sdbusplus::asio::connection& systemBus,
+                     SlotOnFuncType slotOnFunc) :
+        systemBus(systemBus),
+        match(static_cast<sdbusplus::bus::bus&>(systemBus),
+              "type='signal',member='PropertiesChanged',path_namespace='" +
+                  std::string(inventoryPath) + "',arg0namespace='" +
+                  powerStateInterface + "'",
+              [this](
+                  sdbusplus::message_t& msg) { this->powerStateChanged(msg); }),
+        slotOnFunc(std::move(slotOnFunc))
+    {}
+
+    bool isDeviceOff(uint64_t bus, uint64_t address) const;
+
+    bool isDeviceOff(const SensorBaseConfigMap& cfg) const;
+
+    void update(const ManagedObjectType& sensorConfigurations);
+
+  private:
+    struct DeviceInfo
+    {
+        std::string name;
+        std::string type;
+        std::string state;
+        std::string locationCode;
+        uint64_t bus{};
+        uint64_t address{};
+    };
+
+    void powerStateChanged(sdbusplus::message::message& msg);
+    static void getDeviceConfigs(const ManagedObjectType& sensorConfigurations,
+                                 std::vector<DeviceInfo>& deviceConfigs);
+    void getSlots(std::map<std::string, std::string>& slots);
+    std::string getPowerState(const std::string& path);
+
+    sdbusplus::asio::connection& systemBus;
+
+    sdbusplus::bus::match::match match;
+
+    std::map<std::string, std::vector<DeviceInfo>> slotDevices;
+
+    SlotOnFuncType slotOnFunc;
+};
+
+extern std::unique_ptr<SlotPowerManager> slotPowerManager;

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -69,6 +69,7 @@ bool findFiles(const std::filesystem::path& dirPath,
 bool isPowerOn(void);
 bool hasBiosPost(void);
 bool isChassisOn(void);
+bool isPGoodOn();
 void setupPowerMatchCallback(
     const std::shared_ptr<sdbusplus::asio::connection>& conn,
     std::function<void(PowerState type, bool state)>&& callback);
@@ -148,6 +149,14 @@ namespace association
 const static constexpr char* interface =
     "xyz.openbmc_project.Association.Definitions";
 } // namespace association
+
+namespace pgood
+{
+const static constexpr char* busname = "org.openbmc.control.Power";
+const static constexpr char* interface = "org.openbmc.control.Power";
+const static constexpr char* path = "/org/openbmc/control/power0";
+const static constexpr char* property = "pgood";
+} // namespace pgood
 
 template <typename T>
 inline T loadVariant(const SensorBaseConfigMap& data, const std::string& key)

--- a/include/sensor.hpp
+++ b/include/sensor.hpp
@@ -456,17 +456,18 @@ struct Sensor
         }
     }
 
-    void incrementError()
+    // Return true on the call that made the sensor go nonfunctional.
+    bool incrementError()
     {
         if (!readingStateGood())
         {
             markAvailable(false);
-            return;
+            return false;
         }
 
         if (errCount >= errorThreshold)
         {
-            return;
+            return false;
         }
 
         errCount++;
@@ -474,7 +475,9 @@ struct Sensor
         {
             std::cerr << "Sensor " << name << " reading error!\n";
             markFunctional(false);
+            return true;
         }
+        return false;
     }
 
     bool inError() const

--- a/src/HwmonTempMain.cpp
+++ b/src/HwmonTempMain.cpp
@@ -240,14 +240,18 @@ static SensorConfigMap
     return configMap;
 }
 
-boost::container::flat_map<std::string, std::shared_ptr<I2CDevice>>
+// returns a {path: <I2CDevice, is_new>} map.  is_new indicates if the I2CDevice
+// is newly instantiated by this call (true) or was already there (false).
+boost::container::flat_map<std::string,
+                           std::pair<std::shared_ptr<I2CDevice>, bool>>
     instantiateDevices(
         const ManagedObjectType& sensorConfigs,
         const boost::container::flat_map<
             std::string, std::shared_ptr<HwmonTempSensor>>& sensors)
 {
-    boost::container::flat_map<std::string, std::shared_ptr<I2CDevice>>
-        newSensors;
+    boost::container::flat_map<std::string,
+                               std::pair<std::shared_ptr<I2CDevice>, bool>>
+        devices;
     for (const auto& [path, sensor] : sensorConfigs)
     {
         for (const auto& [name, cfg] : sensor)
@@ -270,6 +274,9 @@ boost::container::flat_map<std::string, std::shared_ptr<I2CDevice>>
             if (findSensor != sensors.end() && findSensor->second != nullptr &&
                 findSensor->second->isActive())
             {
+                devices.emplace(
+                    path.str,
+                    std::make_pair(findSensor->second->getI2CDevice(), false));
                 continue;
             }
 
@@ -294,8 +301,10 @@ boost::container::flat_map<std::string, std::shared_ptr<I2CDevice>>
 
                 try
                 {
-                    newSensors.emplace(path.str,
-                                       std::make_shared<I2CDevice>(*params));
+                    devices.emplace(
+                        path.str,
+                        std::make_pair(std::make_shared<I2CDevice>(*params),
+                                       true));
                 }
                 catch (std::runtime_error&)
                 {
@@ -306,7 +315,7 @@ boost::container::flat_map<std::string, std::shared_ptr<I2CDevice>>
             }
         }
     }
-    return newSensors;
+    return devices;
 }
 
 void createSensors(
@@ -326,8 +335,7 @@ void createSensors(
 
         SensorConfigMap configMap = buildSensorConfigMap(sensorConfigurations);
 
-        boost::container::flat_map<std::string, std::shared_ptr<I2CDevice>>
-            newSensors = instantiateDevices(sensorConfigurations, sensors);
+        auto devices = instantiateDevices(sensorConfigurations, sensors);
 
         // IIO _raw devices look like this on sysfs:
         //     /sys/bus/iio/devices/iio:device0/in_temp_raw
@@ -397,16 +405,23 @@ void createSensors(
             }
 
             const std::string& interfacePath = findSensorCfg->second.sensorPath;
-            auto findI2CDev = newSensors.find(interfacePath);
-            if (activateOnly && findI2CDev == newSensors.end())
+            auto findI2CDev = devices.find(interfacePath);
+
+            // If we're only looking to activate newly-instantiated i2c
+            // devices and this sensor's underlying device either (a) wasn't
+            // found (e.g. because it's a static device and not a dynamic one
+            // whose lifetime we're managing) or (b) was already there before
+            // this call, there's nothing more to do here.
+            if (activateOnly &&
+                (findI2CDev == devices.end() || !findI2CDev->second.second))
             {
                 continue;
             }
 
             std::shared_ptr<I2CDevice> i2cDev;
-            if (findI2CDev != newSensors.end())
+            if (findI2CDev != devices.end())
             {
-                i2cDev = findI2CDev->second;
+                i2cDev = findI2CDev->second.first;
             }
 
             const SensorData& sensorData = findSensorCfg->second.sensorData;

--- a/src/HwmonTempMain.cpp
+++ b/src/HwmonTempMain.cpp
@@ -507,7 +507,7 @@ void createSensors(
                         *hwmonFile, sensorType, objectServer, dbusConnection,
                         io, sensorName, std::move(sensorThresholds),
                         thisSensorParameters, pollRate, interfacePath,
-                        readState, i2cDev);
+                        readState, i2cDev, bus, addr);
                     sensor->setupRead();
                 }
             }
@@ -566,7 +566,8 @@ void createSensors(
                             *hwmonFile, sensorType, objectServer,
                             dbusConnection, io, sensorName,
                             std::move(thresholds), thisSensorParameters,
-                            pollRate, interfacePath, readState, i2cDev);
+                            pollRate, interfacePath, readState, i2cDev, bus,
+                            addr);
                         sensor->setupRead();
                     }
                 }

--- a/src/HwmonTempSensor.cpp
+++ b/src/HwmonTempSensor.cpp
@@ -47,7 +47,7 @@ HwmonTempSensor::HwmonTempSensor(
     std::vector<thresholds::Threshold>&& thresholdsIn,
     const struct SensorParams& thisSensorParameters, const float pollRate,
     const std::string& sensorConfiguration, const PowerState powerState,
-    const std::shared_ptr<I2CDevice>& i2cDevice) :
+    const std::shared_ptr<I2CDevice>& i2cDevice, size_t bus, size_t address) :
     Sensor(boost::replace_all_copy(sensorName, " ", "_"),
            std::move(thresholdsIn), sensorConfiguration, objectType, false,
            false, thisSensorParameters.maxValue, thisSensorParameters.minValue,
@@ -56,7 +56,8 @@ HwmonTempSensor::HwmonTempSensor(
     inputDev(io, path, boost::asio::random_access_file::read_only),
     waitTimer(io), path(path), offsetValue(thisSensorParameters.offsetValue),
     scaleValue(thisSensorParameters.scaleValue),
-    sensorPollMs(static_cast<unsigned int>(pollRate * 1000))
+    sensorPollMs(static_cast<unsigned int>(pollRate * 1000)), bus(bus),
+    address(address)
 {
     sensorInterface = objectServer.add_interface(
         "/xyz/openbmc_project/sensors/" + thisSensorParameters.typeName + "/" +

--- a/src/HwmonTempSensor.cpp
+++ b/src/HwmonTempSensor.cpp
@@ -39,6 +39,8 @@
 // For IIO RAW sensors we get a raw_value, an offset, and scale to compute
 // the value = (raw_value + offset) * scale
 
+std::vector<std::pair<size_t, size_t>> HwmonTempSensor::failedDevices{};
+
 HwmonTempSensor::HwmonTempSensor(
     const std::string& path, const std::string& objectType,
     sdbusplus::asio::object_server& objectServer,
@@ -160,6 +162,7 @@ void HwmonTempSensor::restartRead()
 void HwmonTempSensor::handleResponse(const boost::system::error_code& err,
                                      size_t bytesRead)
 {
+    errorCode = err;
     if ((err == boost::system::errc::bad_file_descriptor) ||
         (err == boost::asio::error::misc_errors::not_found))
     {
@@ -176,7 +179,12 @@ void HwmonTempSensor::handleResponse(const boost::system::error_code& err,
             std::from_chars(readBuf.data(), bufEnd, nvalue);
         if (ret.ec != std::errc())
         {
-            incrementError();
+            if (incrementError())
+            {
+                errorCode = boost::system::errc::make_error_code(
+                    boost::system::errc::invalid_argument);
+                createEventLog();
+            }
         }
         else
         {
@@ -185,7 +193,10 @@ void HwmonTempSensor::handleResponse(const boost::system::error_code& err,
     }
     else
     {
-        incrementError();
+        if (incrementError())
+        {
+            createEventLog();
+        }
     }
 
     restartRead();
@@ -194,4 +205,58 @@ void HwmonTempSensor::handleResponse(const boost::system::error_code& err,
 void HwmonTempSensor::checkThresholds(void)
 {
     thresholds::checkThresholds(this);
+}
+
+void HwmonTempSensor::clearFailedDevices()
+{
+    failedDevices.clear();
+}
+
+// Creates a ReadFailure event log if the power is on and if the
+// device hasn't previously had an error logged against it.
+void HwmonTempSensor::createEventLog()
+{
+    if (!isChassisOn())
+    {
+        return;
+    }
+
+    if (std::find(failedDevices.begin(), failedDevices.end(),
+                  std::make_pair(bus, address)) != failedDevices.end())
+    {
+        // Already have a failure on this device
+        return;
+    }
+
+    failedDevices.emplace_back(bus, address);
+
+    std::cerr << "Creating event log for sensor " << name << " read failure on "
+              << path << " with error code " << errorCode.value() << "\n";
+
+    std::map<std::string, std::string> additionalData;
+
+    additionalData["SENSOR_NAME"] = name;
+    additionalData["CALLOUT_IIC_BUS"] = std::to_string(bus);
+    additionalData["CALLOUT_IIC_ADDR"] = std::to_string(address);
+    additionalData["CALLOUT_ERRNO"] = std::to_string(errorCode.value());
+    additionalData["IIC_ERROR_CATEGORY"] = errorCode.category().name();
+    additionalData["IIC_ERROR_MESSAGE"] =
+        errorCode.category().message(errorCode.value());
+    additionalData["FILE"] = path;
+    additionalData["_PID"] = std::to_string(getpid());
+
+    dbusConnection->async_method_call(
+        [this](const boost::system::error_code ec) {
+        if (ec)
+        {
+            std::cerr << "Failed to create an event log for "
+                         "a failed read on sensor "
+                      << name << "\n";
+            return;
+        }
+        },
+        "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+        "xyz.openbmc_project.Logging.Create", "Create",
+        "xyz.openbmc_project.Sensor.Device.Error.ReadFailure",
+        "xyz.openbmc_project.Logging.Entry.Level.Error", additionalData);
 }

--- a/src/HwmonTempSensor.cpp
+++ b/src/HwmonTempSensor.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 */
 
+#include "SlotPowerManager.hpp"
+
 #include <unistd.h>
 
 #include <HwmonTempSensor.hpp>
@@ -121,7 +123,7 @@ HwmonTempSensor::~HwmonTempSensor()
 
 void HwmonTempSensor::setupRead(void)
 {
-    if (!readingStateGood())
+    if (!readingStateGood() || slotPowerManager->isDeviceOff(bus, address))
     {
         markAvailable(false);
         updateValue(std::numeric_limits<double>::quiet_NaN());

--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -1,0 +1,301 @@
+#include "SlotPowerManager.hpp"
+
+#include <boost/algorithm/string/replace.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+PHOSPHOR_LOG2_USING;
+namespace fs = std::filesystem;
+
+std::unique_ptr<SlotPowerManager> slotPowerManager;
+
+static const char* locationCodeInterface =
+    "xyz.openbmc_project.Inventory.Decorator.LocationCode";
+static const char* pcieSlotInterface =
+    "xyz.openbmc_project.Inventory.Item.PCIeSlot";
+
+void SlotPowerManager::update(const ManagedObjectType& sensorConfigurations)
+{
+    std::vector<std::string> newSlots;
+    std::vector<DeviceInfo> deviceConfigs;
+    static std::map<std::string, std::string> slots;
+
+    // Pull the applicable device configs out of the EM D-Bus objects
+    getDeviceConfigs(sensorConfigurations, deviceConfigs);
+    if (deviceConfigs.empty())
+    {
+        return;
+    }
+
+    debug("Found {SIZE} device configs", "SIZE", deviceConfigs.size());
+
+    // Get map of locations codes to their slots
+    if (slots.empty())
+    {
+        getSlots(slots);
+    }
+
+    // Build the slotDevices map
+    for (auto& deviceInfo : deviceConfigs)
+    {
+        auto slotNameIt = slots.find(deviceInfo.locationCode);
+        if (slotNameIt == slots.end())
+        {
+            error("No slot found for sensor location code {LOC}", "LOC",
+                  deviceInfo.locationCode);
+            continue;
+        }
+
+        const auto& slotName = slotNameIt->second;
+        auto powerState = getPowerState(slotName);
+
+        auto slotDataIt = slotDevices.find(slotName);
+        if (slotDataIt == slotDevices.end())
+        {
+            debug("Initial power state of {SLOT} is {STATE}", "SLOT", slotName,
+                  "STATE", powerState);
+            deviceInfo.state = powerState;
+            slotDevices.emplace(slotName, std::vector{deviceInfo});
+            newSlots.push_back(slotName);
+        }
+        else
+        {
+            // Add another device to this slot.  As update() can get
+            // called multiple times with the same set of slots, only
+            // allow this if we added the slot for the first time in
+            // this function call.
+            if (std::find(newSlots.begin(), newSlots.end(), slotName) !=
+                newSlots.end())
+            {
+                deviceInfo.state = powerState;
+                slotDataIt->second.push_back(deviceInfo);
+            }
+        }
+    }
+}
+
+// Find the devices on slot power
+void SlotPowerManager::getDeviceConfigs(
+    const ManagedObjectType& sensorConfigurations,
+    std::vector<DeviceInfo>& deviceConfigs)
+{
+    for (const auto& [objectPath, sensorData] : sensorConfigurations)
+    {
+        for (const auto& [type, config] : sensorData)
+        {
+            auto ownerIt = config.find("PowerStateOwner");
+            if (ownerIt == config.end())
+            {
+                continue;
+            }
+
+            const auto& owner = std::get<std::string>(ownerIt->second);
+            if (owner != "PCIeSlot")
+            {
+                error("Invalid PowerStateOwner type: {OWNER} in entity-manager "
+                      "config",
+                      "OWNER", owner);
+                continue;
+            }
+
+            auto locCodeIt = config.find("LocationCode");
+            if (locCodeIt == config.end())
+            {
+                error("Missing LocationCode entry on {PATH}", "PATH",
+                      objectPath.str);
+                continue;
+            }
+
+            if (!config.contains("Bus") || !config.contains("Address"))
+            {
+                error("Missing Bus or Address for {PATH}", "PATH",
+                      objectPath.str);
+                continue;
+            }
+
+            if ((std::get_if<uint64_t>(&config.at("Bus")) == nullptr) ||
+                (std::get_if<uint64_t>(&config.at("Address")) == nullptr))
+            {
+                error("Invalid Bus or Address for {PATH}", "PATH",
+                      objectPath.str);
+                continue;
+            }
+
+            DeviceInfo deviceInfo;
+            deviceInfo.name = std::get<std::string>(config.at("Name"));
+            deviceInfo.type = std::get<std::string>(config.at("Type"));
+            deviceInfo.bus = std::get<uint64_t>(config.at("Bus"));
+            deviceInfo.address = std::get<uint64_t>(config.at("Address"));
+            deviceInfo.locationCode = std::get<std::string>(locCodeIt->second);
+
+            debug("DeviceInfo: Name: {NAME}, Type: {TYPE}", "NAME",
+                  deviceInfo.name, "TYPE", deviceInfo.type);
+
+            deviceConfigs.push_back(std::move(deviceInfo));
+        }
+    }
+}
+
+// Build the locCode->slotPath map
+void SlotPowerManager::getSlots(std::map<std::string, std::string>& slots)
+{
+    auto& bus = static_cast<sdbusplus::bus_t&>(systemBus);
+
+    auto method = bus.new_method_call(mapper::busName, mapper::path,
+                                      mapper::interface, mapper::subtree);
+    method.append(std::string{"/"}, 0,
+                  std::vector<std::string>{pcieSlotInterface});
+    auto reply = bus.call(method);
+
+    GetSubTreeType subtree;
+    reply.read(subtree);
+
+    for (const auto& [path, objDict] : subtree)
+    {
+        const auto& busName = objDict[0].first;
+        auto method =
+            bus.new_method_call(busName.c_str(), path.c_str(),
+                                properties::interface, properties::get);
+        method.append(locationCodeInterface, "LocationCode");
+
+        try
+        {
+            auto reply = bus.call(method);
+
+            std::variant<std::string> locationCode;
+            reply.read(locationCode);
+            const auto& locCode = std::get<std::string>(locationCode);
+            slots.emplace(locCode, path);
+        }
+        catch (const sdbusplus::exception_t& ex)
+        {
+            error("Failed getting location code from {PATH}: {EX}", "PATH",
+                  path, "EX", ex);
+        }
+    }
+}
+
+std::string SlotPowerManager::getPowerState(const std::string& path)
+{
+    auto& bus = static_cast<sdbusplus::bus_t&>(systemBus);
+    static GetSubTreeType subtree;
+
+    // Get the list of power state objects just once.
+    if (subtree.empty())
+    {
+        auto method = bus.new_method_call(mapper::busName, mapper::path,
+                                          mapper::interface, mapper::subtree);
+        method.append(std::string{"/"}, 0,
+                      std::vector<std::string>{powerStateInterface});
+        auto reply = bus.call(method);
+        reply.read(subtree);
+    }
+
+    auto entryIt = std::find_if(subtree.begin(), subtree.end(),
+                                [path](const auto& subtreeEntry) {
+        return path == subtreeEntry.first;
+    });
+    if (entryIt == subtree.end())
+    {
+        throw std::runtime_error("No power state interface on " + path);
+    }
+
+    const auto& services = entryIt->second;
+
+    auto method = bus.new_method_call(services[0].first.c_str(), path.c_str(),
+                                      properties::interface, properties::get);
+    method.append(powerStateInterface, "PowerState");
+
+    auto reply = bus.call(method);
+
+    std::variant<std::string> powerState;
+    reply.read(powerState);
+
+    return std::get<std::string>(powerState);
+}
+
+void SlotPowerManager::powerStateChanged(sdbusplus::message_t& msg)
+{
+    std::string objectPath = msg.get_path();
+    std::string interface;
+    std::map<std::string, std::variant<std::string>> properties;
+
+    msg.read(interface, properties);
+
+    auto propIt = properties.find("PowerState");
+    if (propIt == properties.end())
+    {
+        return;
+    }
+
+    if (!slotDevices.contains(objectPath))
+    {
+        // Don't care about this slot
+        return;
+    }
+
+    debug("Power state of {PATH} changed to {STATE}", "PATH", objectPath,
+          "STATE", std::get<std::string>(propIt->second));
+
+    const auto& powerState = std::get<std::string>(propIt->second);
+
+    // Update the state inside the config data.
+    auto& deviceConfigs = slotDevices.at(objectPath);
+    std::for_each(deviceConfigs.begin(), deviceConfigs.end(),
+                  [powerState](auto& config) { config.state = powerState; });
+
+    // Call slotOnFunc with the name of the sensor that changed
+    if (powerState.ends_with("On") && slotOnFunc)
+    {
+        auto sensors =
+            std::make_shared<boost::container::flat_set<std::string>>();
+
+        std::for_each(deviceConfigs.begin(), deviceConfigs.end(),
+                      [&sensors](const auto& config) {
+            // createSensors() doesn't want spaces
+            auto name = boost::replace_all_copy(config.name, " ", "_");
+            sensors->insert(name);
+        });
+        // Call createSensors() (which calls update())
+        slotOnFunc(sensors);
+    }
+}
+
+bool SlotPowerManager::isDeviceOff(const SensorBaseConfigMap& cfg) const
+{
+    auto findBus = cfg.find("Bus");
+    auto findAddr = cfg.find("Address");
+
+    if (findBus == cfg.end() || findAddr == cfg.end())
+    {
+        return false;
+    }
+
+    const uint64_t* bus = std::get_if<uint64_t>(&findBus->second);
+    const uint64_t* addr = std::get_if<uint64_t>(&findAddr->second);
+
+    if (bus == nullptr || addr == nullptr)
+    {
+        return false;
+    }
+    return isDeviceOff(*bus, *addr);
+}
+
+bool SlotPowerManager::isDeviceOff(uint64_t bus, uint64_t address) const
+{
+    for (const auto& [_, devices] : slotDevices)
+    {
+        auto deviceIt = std::find_if(devices.begin(), devices.end(),
+                                     [bus, address](const auto& device) {
+            return (bus == device.bus) && (address == device.address);
+        });
+
+        if (deviceIt != devices.end())
+        {
+            return boost::ends_with(deviceIt->state, "Off");
+        }
+    }
+    return false;
+}

--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -294,7 +294,7 @@ bool SlotPowerManager::isDeviceOff(uint64_t bus, uint64_t address) const
 
         if (deviceIt != devices.end())
         {
-            return boost::ends_with(deviceIt->state, "Off");
+            return !deviceIt->state.ends_with("On") || !isChassisOn();
         }
     }
     return false;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -39,10 +39,12 @@ static bool powerStatusOn = false;
 static bool biosHasPost = false;
 static bool manufacturingMode = false;
 static bool chassisStatusOn = false;
+static bool pgoodStatus = false;
 
 static std::unique_ptr<sdbusplus::bus::match_t> powerMatch = nullptr;
 static std::unique_ptr<sdbusplus::bus::match_t> postMatch = nullptr;
 static std::unique_ptr<sdbusplus::bus::match_t> chassisMatch = nullptr;
+static std::unique_ptr<sdbusplus::bus::match_t> pgoodMatch = nullptr;
 
 /**
  * return the contents of a file
@@ -296,6 +298,15 @@ bool isPowerOn(void)
     return powerStatusOn;
 }
 
+bool isPGoodOn()
+{
+    if (!pgoodMatch)
+    {
+        throw std::runtime_error("PGood Match Not Created");
+    }
+    return pgoodStatus;
+}
+
 bool hasBiosPost(void)
 {
     if (!postMatch)
@@ -311,7 +322,7 @@ bool isChassisOn(void)
     {
         throw std::runtime_error("Chassis On Match Not Created");
     }
-    return chassisStatusOn;
+    return chassisStatusOn && isPGoodOn();
 }
 
 bool readingStateGood(const PowerState& powerState)
@@ -362,6 +373,36 @@ static void
         },
         power::busname, power::path, properties::interface, properties::get,
         power::interface, power::property);
+}
+
+static void
+    getPGoodStatus(const std::shared_ptr<sdbusplus::asio::connection>& conn,
+                   size_t retries = 2)
+{
+    conn->async_method_call(
+        [conn, retries](boost::system::error_code ec,
+                        const std::variant<int>& pgoodValue) {
+        if (ec)
+        {
+            if (retries != 0U)
+            {
+                auto timer = std::make_shared<boost::asio::steady_timer>(
+                    conn->get_io_context());
+                timer->expires_after(std::chrono::seconds(15));
+                timer->async_wait(
+                    [timer, conn, retries](boost::system::error_code) {
+                    getPGoodStatus(conn, retries - 1);
+                });
+                return;
+            }
+
+            std::cerr << "error getting pgood status " << ec.message() << "\n";
+            return;
+        }
+        pgoodStatus = std::get<int>(pgoodValue) != 0;
+        },
+        pgood::busname, pgood::path, properties::interface, properties::get,
+        pgood::interface, pgood::property);
 }
 
 static void
@@ -546,9 +587,27 @@ void setupPowerMatchCallback(
             });
         }
         });
+
+    pgoodMatch = std::make_unique<sdbusplus::bus::match_t>(
+        static_cast<sdbusplus::bus_t&>(*conn),
+        "type='signal',interface='" + std::string(properties::interface) +
+            "',path='" + std::string(pgood::path) + "',arg0='" +
+            std::string(pgood::interface) + "'",
+        [](sdbusplus::message_t& message) {
+        std::string objectName;
+        boost::container::flat_map<std::string, std::variant<int>> values;
+        message.read(objectName, values);
+        auto findPGood = values.find(pgood::property);
+        if (findPGood != values.end())
+        {
+            pgoodStatus = std::get<int>(findPGood->second) != 0;
+        }
+        });
+
     getPowerStatus(conn);
     getPostStatus(conn);
     getChassisStatus(conn);
+    getPGoodStatus(conn);
 }
 
 void setupPowerMatch(const std::shared_ptr<sdbusplus::asio::connection>& conn)

--- a/src/meson.build
+++ b/src/meson.build
@@ -80,6 +80,7 @@ if get_option('hwmon-temp').enabled()
         'hwmontempsensor',
         'HwmonTempMain.cpp',
         'HwmonTempSensor.cpp',
+        'SlotPowerManager.cpp',
         dependencies: [
             default_deps,
             devicemgmt_dep,


### PR DESCRIPTION
Had to pull over my commits from 1030 into hwmontempsensor.

This provides:
* Creating PELs for failed sensor reads
* Add support for the TMP435s on the Flett and Bear River/Lake cards that only have power after PHYP turns on the slot.

Also has an external fix that's now in master  `hwmontempsensor: Fix crash on eventHandler signal callback`.

Had to do some minor refactoring of mine from 1030 due to changes in master.