### PR TITLE
hwmontemp: Fix object type being passed to ctors

### DIFF
--- a/include/sensor.hpp
+++ b/include/sensor.hpp
@@ -64,7 +64,7 @@ struct Sensor
            PowerState readState = PowerState::always) :
         name(sensor_paths::escapePathForDbus(name)),
         configurationPath(configurationPath),
-        objectType(configInterfaceName(objectType)),
+        configInterface(configInterfaceName(objectType)),
         isSensorSettable(isSettable), isValueMutable(isMutable), maxValue(max),
         minValue(min), thresholds(std::move(thresholdData)),
         hysteresisTrigger((max - min) * 0.01),
@@ -78,7 +78,7 @@ struct Sensor
     virtual void checkThresholds(void) = 0;
     std::string name;
     std::string configurationPath;
-    std::string objectType;
+    std::string configInterface;
     bool isSensorSettable;
 
     /* A flag indicates if properties of xyz.openbmc_project.Sensor.Value
@@ -152,7 +152,7 @@ struct Sensor
         if ((inst.numCollectsGood == 0) && (inst.numCollectsMiss == 0))
         {
             std::cerr << "Sensor " << name << ": Configuration min=" << minValue
-                      << ", max=" << maxValue << ", type=" << objectType
+                      << ", max=" << maxValue << ", type=" << configInterface
                       << ", path=" << configurationPath << "\n";
         }
 
@@ -307,7 +307,7 @@ struct Sensor
                 [&, label, thresSize](const double& request, double& oldValue) {
                 oldValue = request; // todo, just let the config do this?
                 threshold.value = request;
-                thresholds::persistThreshold(configurationPath, objectType,
+                thresholds::persistThreshold(configurationPath, configInterface,
                                              threshold, dbusConnection,
                                              thresSize, label);
                 // Invalidate previously remembered value,

--- a/src/HwmonTempMain.cpp
+++ b/src/HwmonTempMain.cpp
@@ -443,7 +443,12 @@ void createSensors(
             }
 
             const SensorData& sensorData = findSensorCfg->second.sensorData;
-            const std::string& sensorType = findSensorCfg->second.interface;
+            std::string sensorType = findSensorCfg->second.interface;
+            auto pos = sensorType.find_last_of('.');
+            if (pos != std::string::npos)
+            {
+                sensorType = sensorType.substr(pos + 1);
+            }
             const SensorBaseConfigMap& baseConfigMap =
                 findSensorCfg->second.config;
             std::vector<std::string>& hwmonName = findSensorCfg->second.name;

--- a/src/HwmonTempMain.cpp
+++ b/src/HwmonTempMain.cpp
@@ -636,7 +636,7 @@ void interfaceRemoved(
     {
         if ((sensorIt->second->configurationPath == path) &&
             (std::find(interfaces.begin(), interfaces.end(),
-                       sensorIt->second->objectType) != interfaces.end()))
+                       sensorIt->second->configInterface) != interfaces.end()))
         {
             sensorIt = sensors.erase(sensorIt);
         }

--- a/src/NVMeSensorMain.cpp
+++ b/src/NVMeSensorMain.cpp
@@ -216,7 +216,7 @@ static void interfaceRemoved(sdbusplus::message_t& message, NVMEMap& contexts)
         }
 
         auto interface = std::find(interfaces.begin(), interfaces.end(),
-                                   (*sensor)->objectType);
+                                   (*sensor)->configInterface);
         if (interface == interfaces.end())
         {
             continue;


### PR DESCRIPTION
The Sensor base class is now tacking on the
'xyz.openbmc_project.Configuration' prefix to the objectType argument
passed into its constructor.  But in createSensors() the value passed
into the constructor was already the full interface name taken from the
buildSensorConfigMap() output, so the prefix ended up being in the
objectType member variable twice.

This was causing the InterfacesRemoved handler to not find an interface
match when entity-manager removed interfaces, leaving sensors on D-Bus
for hardware that was no longer in the system.

Fix it by stripping off all but the last segment before passing it to
the sensor object constructor.

The second commit just changes the Sensor class configuration interface member variable name to 'configInterface' from 'objectType'.