### PR TITLE
Pull 1060 downstream changes into 1110

### DIFF
--- a/src/DeviceMgmt.hpp
+++ b/src/DeviceMgmt.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "SlotPowerManager.hpp"
 #include "Utils.hpp"
 
 #include <boost/container/flat_map.hpp>
@@ -127,6 +128,11 @@ boost::container::flat_map<std::string,
                 devices.emplace(
                     path.str,
                     std::make_pair(findSensor->getI2CDevice(), false));
+                continue;
+            }
+
+            if (slotPowerManager->isDeviceOff(cfg))
+            {
                 continue;
             }
 

--- a/src/HwmonTempMain.cpp
+++ b/src/HwmonTempMain.cpp
@@ -551,6 +551,29 @@ void interfaceRemoved(
     }
 }
 
+void checkForErrors(
+    PowerState type, bool newState,
+    boost::container::flat_map<std::string, std::shared_ptr<HwmonTempSensor>>&
+        sensors)
+{
+    // Only check when chassis power is turning on
+    if ((type != PowerState::chassisOn) || (!newState))
+    {
+        return;
+    }
+
+    // Forget about previous fails.
+    HwmonTempSensor::clearFailedDevices();
+
+    for (const auto& [name, sensor] : sensors)
+    {
+        if ((sensor->errCount >= errorThreshold) && std::isnan(sensor->value))
+        {
+            sensor->createEventLog();
+        }
+    }
+}
+
 static void powerStateChanged(
     PowerState type, bool newState,
     boost::container::flat_map<std::string, std::shared_ptr<HwmonTempSensor>>&
@@ -572,6 +595,8 @@ static void powerStateChanged(
             }
         }
     }
+
+    checkForErrors(type, newState, sensors);
 }
 
 int main()

--- a/src/HwmonTempMain.cpp
+++ b/src/HwmonTempMain.cpp
@@ -434,7 +434,7 @@ void createSensors(
                         *hwmonFile, sensorType, objectServer, dbusConnection,
                         io, sensorName, std::move(sensorThresholds),
                         thisSensorParameters, pollRate, interfacePath,
-                        readState, i2cDev);
+                        readState, i2cDev, bus, addr);
                     sensor->setupRead();
                 }
             }
@@ -493,7 +493,8 @@ void createSensors(
                             *hwmonFile, sensorType, objectServer,
                             dbusConnection, io, sensorName,
                             std::move(thresholds), thisSensorParameters,
-                            pollRate, interfacePath, readState, i2cDev);
+                            pollRate, interfacePath, readState, i2cDev, bus,
+                            addr);
                         sensor->setupRead();
                     }
                 }

--- a/src/HwmonTempMain.cpp
+++ b/src/HwmonTempMain.cpp
@@ -16,6 +16,7 @@
 
 #include "DeviceMgmt.hpp"
 #include "HwmonTempSensor.hpp"
+#include "SlotPowerManager.hpp"
 #include "Utils.hpp"
 
 #include <boost/algorithm/string/replace.hpp>
@@ -75,6 +76,7 @@ static const I2CDeviceTypeMap sensorTypes{
     {"TMP112", I2CDeviceType{"tmp112", true}},
     {"TMP175", I2CDeviceType{"tmp175", true}},
     {"TMP421", I2CDeviceType{"tmp421", true}},
+    {"TMP435", I2CDeviceType{"tmp435", true}},
     {"TMP441", I2CDeviceType{"tmp441", true}},
     {"TMP461", I2CDeviceType{"tmp461", true}},
     {"TMP464", I2CDeviceType{"tmp464", true}},
@@ -261,6 +263,8 @@ void createSensors(
         [&io, &objectServer, &sensors, &dbusConnection, sensorsChanged,
          activateOnly](const ManagedObjectType& sensorConfigurations) {
         bool firstScan = sensorsChanged == nullptr;
+
+        slotPowerManager->update(sensorConfigurations);
 
         SensorConfigMap configMap = buildSensorConfigMap(sensorConfigurations);
 
@@ -617,6 +621,11 @@ int main()
         powerStateChanged(type, state, sensors, io, objectServer, systemBus);
     };
     setupPowerMatchCallback(systemBus, powerCallBack);
+
+    slotPowerManager = std::make_unique<SlotPowerManager>(
+        *systemBus, [&](const auto& newSensors) {
+        createSensors(io, objectServer, sensors, systemBus, newSensors, false);
+    });
 
     boost::asio::post(io, [&]() {
         createSensors(io, objectServer, sensors, systemBus, nullptr, false);

--- a/src/HwmonTempSensor.cpp
+++ b/src/HwmonTempSensor.cpp
@@ -48,7 +48,7 @@ HwmonTempSensor::HwmonTempSensor(
     std::vector<thresholds::Threshold>&& thresholdsIn,
     const struct SensorParams& thisSensorParameters, const float pollRate,
     const std::string& sensorConfiguration, const PowerState powerState,
-    const std::shared_ptr<I2CDevice>& i2cDevice) :
+    const std::shared_ptr<I2CDevice>& i2cDevice, size_t bus, size_t address) :
     Sensor(boost::replace_all_copy(sensorName, " ", "_"),
            std::move(thresholdsIn), sensorConfiguration, objectType, false,
            false, thisSensorParameters.maxValue, thisSensorParameters.minValue,
@@ -57,7 +57,8 @@ HwmonTempSensor::HwmonTempSensor(
     inputDev(io, path, boost::asio::random_access_file::read_only),
     waitTimer(io), path(path), offsetValue(thisSensorParameters.offsetValue),
     scaleValue(thisSensorParameters.scaleValue),
-    sensorPollMs(static_cast<unsigned int>(pollRate * 1000))
+    sensorPollMs(static_cast<unsigned int>(pollRate * 1000)), bus(bus),
+    address(address)
 {
     sensorInterface = objectServer.add_interface(
         "/xyz/openbmc_project/sensors/" + thisSensorParameters.typeName + "/" +

--- a/src/HwmonTempSensor.cpp
+++ b/src/HwmonTempSensor.cpp
@@ -16,6 +16,8 @@
 
 #include "HwmonTempSensor.hpp"
 
+#include "SlotPowerManager.hpp"
+
 #include <unistd.h>
 
 #include <boost/asio/read_until.hpp>
@@ -122,7 +124,7 @@ HwmonTempSensor::~HwmonTempSensor()
 
 void HwmonTempSensor::setupRead(void)
 {
-    if (!readingStateGood())
+    if (!readingStateGood() || slotPowerManager->isDeviceOff(bus, address))
     {
         markAvailable(false);
         updateValue(std::numeric_limits<double>::quiet_NaN());
@@ -255,7 +257,7 @@ void HwmonTempSensor::createEventLog()
                       << name << "\n";
             return;
         }
-        },
+    },
         "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
         "xyz.openbmc_project.Logging.Create", "Create",
         "xyz.openbmc_project.Sensor.Device.Error.ReadFailure",

--- a/src/HwmonTempSensor.hpp
+++ b/src/HwmonTempSensor.hpp
@@ -33,7 +33,8 @@ class HwmonTempSensor :
                     const struct SensorParams& thisSensorParameters,
                     float pollRate, const std::string& sensorConfiguration,
                     PowerState powerState,
-                    const std::shared_ptr<I2CDevice>& i2cDevice);
+                    const std::shared_ptr<I2CDevice>& i2cDevice, size_t bus,
+                    size_t address);
     ~HwmonTempSensor() override;
     void setupRead(void);
     void activate(const std::string& newPath,
@@ -58,6 +59,8 @@ class HwmonTempSensor :
     double offsetValue;
     double scaleValue;
     unsigned int sensorPollMs;
+    size_t bus;
+    size_t address;
 
     void handleResponse(const boost::system::error_code& err, size_t bytesRead);
     void restartRead();

--- a/src/HwmonTempSensor.hpp
+++ b/src/HwmonTempSensor.hpp
@@ -47,6 +47,12 @@ class HwmonTempSensor :
         return i2cDevice;
     }
 
+    // Clears the history of failed reads
+    static void clearFailedDevices();
+
+    // Create an event log for a failed read
+    void createEventLog();
+
   private:
     // Ordering is important here; readBuf is first so that it's not destroyed
     // while async operations from other member fields might still be using it.
@@ -61,6 +67,12 @@ class HwmonTempSensor :
     unsigned int sensorPollMs;
     size_t bus;
     size_t address;
+
+    // pair<bus, address> of devices with logged failed reads
+    static std::vector<std::pair<size_t, size_t>> failedDevices;
+
+    // The error code from the last HW access for the sensor.
+    boost::system::error_code errorCode;
 
     void handleResponse(const boost::system::error_code& err, size_t bytesRead);
     void restartRead();

--- a/src/NVMeSensor.cpp
+++ b/src/NVMeSensor.cpp
@@ -16,6 +16,7 @@
 
 #include "NVMeSensor.hpp"
 
+#include <filesystem>
 #include <iostream>
 
 static constexpr double maxReading = 127;
@@ -68,6 +69,53 @@ NVMeSensor::~NVMeSensor()
     }
     objServer.remove_interface(sensorInterface);
     objServer.remove_interface(association);
+}
+
+void NVMeSensor::createAssociation()
+{
+    std::filesystem::path p(configurationPath);
+    dbusConnection->async_method_call(
+        [association = association,
+         configurationPath = this->configurationPath](
+            const boost::system::error_code ec,
+            const std::variant<std::vector<Association>>& envelope) {
+        if (ec == boost::asio::error::operation_aborted)
+        {
+            return;
+        }
+
+        if (ec)
+        {
+            std::cerr << "Error getting inventory association for "
+                      << configurationPath << ": " << ec.message() << "\n";
+            return;
+        }
+
+        std::vector<Association> sensorAssociations = {
+            {
+                "chassis",
+                "all_sensors",
+                "/xyz/openbmc_project/inventory/system/chassis",
+            },
+        };
+
+        auto configAssociations = std::get<std::vector<Association>>(envelope);
+        for (const auto& entry : configAssociations)
+        {
+            if (std::get<0>(entry) == "probed_by")
+            {
+                const auto& invPath = std::get<2>(entry);
+                sensorAssociations.emplace_back("inventory", "sensors",
+                                                invPath);
+            }
+        }
+
+        association->register_property("Associations", sensorAssociations);
+        association->initialize();
+    },
+        entityManagerName, p.parent_path().string(),
+        "org.freedesktop.DBus.Properties", "Get", association::interface,
+        "Associations");
 }
 
 bool NVMeSensor::sample()

--- a/src/NVMeSensor.hpp
+++ b/src/NVMeSensor.hpp
@@ -19,6 +19,8 @@ class NVMeSensor : public Sensor
 
     NVMeSensor& operator=(const NVMeSensor& other) = delete;
 
+    void createAssociation() override;
+
     bool sample();
 
     const int bus;

--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -294,7 +294,7 @@ bool SlotPowerManager::isDeviceOff(uint64_t bus, uint64_t address) const
 
         if (deviceIt != devices.end())
         {
-            return deviceIt->state.ends_with("Off");
+            return !deviceIt->state.ends_with("On") || !isChassisOn();
         }
     }
     return false;

--- a/src/SlotPowerManager.cpp
+++ b/src/SlotPowerManager.cpp
@@ -1,0 +1,301 @@
+#include "SlotPowerManager.hpp"
+
+#include <boost/algorithm/string/replace.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+PHOSPHOR_LOG2_USING;
+namespace fs = std::filesystem;
+
+std::unique_ptr<SlotPowerManager> slotPowerManager;
+
+static const char* locationCodeInterface =
+    "xyz.openbmc_project.Inventory.Decorator.LocationCode";
+static const char* pcieSlotInterface =
+    "xyz.openbmc_project.Inventory.Item.PCIeSlot";
+
+void SlotPowerManager::update(const ManagedObjectType& sensorConfigurations)
+{
+    std::vector<std::string> newSlots;
+    std::vector<DeviceInfo> deviceConfigs;
+    static std::map<std::string, std::string> slots;
+
+    // Pull the applicable device configs out of the EM D-Bus objects
+    getDeviceConfigs(sensorConfigurations, deviceConfigs);
+    if (deviceConfigs.empty())
+    {
+        return;
+    }
+
+    debug("Found {SIZE} device configs", "SIZE", deviceConfigs.size());
+
+    // Get map of locations codes to their slots
+    if (slots.empty())
+    {
+        getSlots(slots);
+    }
+
+    // Build the slotDevices map
+    for (auto& deviceInfo : deviceConfigs)
+    {
+        auto slotNameIt = slots.find(deviceInfo.locationCode);
+        if (slotNameIt == slots.end())
+        {
+            error("No slot found for sensor location code {LOC}", "LOC",
+                  deviceInfo.locationCode);
+            continue;
+        }
+
+        const auto& slotName = slotNameIt->second;
+        auto powerState = getPowerState(slotName);
+
+        auto slotDataIt = slotDevices.find(slotName);
+        if (slotDataIt == slotDevices.end())
+        {
+            debug("Initial power state of {SLOT} is {STATE}", "SLOT", slotName,
+                  "STATE", powerState);
+            deviceInfo.state = powerState;
+            slotDevices.emplace(slotName, std::vector{deviceInfo});
+            newSlots.push_back(slotName);
+        }
+        else
+        {
+            // Add another device to this slot.  As update() can get
+            // called multiple times with the same set of slots, only
+            // allow this if we added the slot for the first time in
+            // this function call.
+            if (std::find(newSlots.begin(), newSlots.end(), slotName) !=
+                newSlots.end())
+            {
+                deviceInfo.state = powerState;
+                slotDataIt->second.push_back(deviceInfo);
+            }
+        }
+    }
+}
+
+// Find the devices on slot power
+void SlotPowerManager::getDeviceConfigs(
+    const ManagedObjectType& sensorConfigurations,
+    std::vector<DeviceInfo>& deviceConfigs)
+{
+    for (const auto& [objectPath, sensorData] : sensorConfigurations)
+    {
+        for (const auto& [type, config] : sensorData)
+        {
+            auto ownerIt = config.find("PowerStateOwner");
+            if (ownerIt == config.end())
+            {
+                continue;
+            }
+
+            const auto& owner = std::get<std::string>(ownerIt->second);
+            if (owner != "PCIeSlot")
+            {
+                error("Invalid PowerStateOwner type: {OWNER} in entity-manager "
+                      "config",
+                      "OWNER", owner);
+                continue;
+            }
+
+            auto locCodeIt = config.find("LocationCode");
+            if (locCodeIt == config.end())
+            {
+                error("Missing LocationCode entry on {PATH}", "PATH",
+                      objectPath.str);
+                continue;
+            }
+
+            if (!config.contains("Bus") || !config.contains("Address"))
+            {
+                error("Missing Bus or Address for {PATH}", "PATH",
+                      objectPath.str);
+                continue;
+            }
+
+            if ((std::get_if<uint64_t>(&config.at("Bus")) == nullptr) ||
+                (std::get_if<uint64_t>(&config.at("Address")) == nullptr))
+            {
+                error("Invalid Bus or Address for {PATH}", "PATH",
+                      objectPath.str);
+                continue;
+            }
+
+            DeviceInfo deviceInfo;
+            deviceInfo.name = std::get<std::string>(config.at("Name"));
+            deviceInfo.type = std::get<std::string>(config.at("Type"));
+            deviceInfo.bus = std::get<uint64_t>(config.at("Bus"));
+            deviceInfo.address = std::get<uint64_t>(config.at("Address"));
+            deviceInfo.locationCode = std::get<std::string>(locCodeIt->second);
+
+            debug("DeviceInfo: Name: {NAME}, Type: {TYPE}", "NAME",
+                  deviceInfo.name, "TYPE", deviceInfo.type);
+
+            deviceConfigs.push_back(std::move(deviceInfo));
+        }
+    }
+}
+
+// Build the locCode->slotPath map
+void SlotPowerManager::getSlots(std::map<std::string, std::string>& slots)
+{
+    auto& bus = static_cast<sdbusplus::bus_t&>(systemBus);
+
+    auto method = bus.new_method_call(mapper::busName, mapper::path,
+                                      mapper::interface, mapper::subtree);
+    method.append(std::string{"/"}, 0,
+                  std::vector<std::string>{pcieSlotInterface});
+    auto reply = bus.call(method);
+
+    GetSubTreeType subtree;
+    reply.read(subtree);
+
+    for (const auto& [path, objDict] : subtree)
+    {
+        const auto& busName = objDict[0].first;
+        auto method = bus.new_method_call(busName.c_str(), path.c_str(),
+                                          properties::interface,
+                                          properties::get);
+        method.append(locationCodeInterface, "LocationCode");
+
+        try
+        {
+            auto reply = bus.call(method);
+
+            std::variant<std::string> locationCode;
+            reply.read(locationCode);
+            const auto& locCode = std::get<std::string>(locationCode);
+            slots.emplace(locCode, path);
+        }
+        catch (const sdbusplus::exception_t& ex)
+        {
+            error("Failed getting location code from {PATH}: {EX}", "PATH",
+                  path, "EX", ex);
+        }
+    }
+}
+
+std::string SlotPowerManager::getPowerState(const std::string& path)
+{
+    auto& bus = static_cast<sdbusplus::bus_t&>(systemBus);
+    static GetSubTreeType subtree;
+
+    // Get the list of power state objects just once.
+    if (subtree.empty())
+    {
+        auto method = bus.new_method_call(mapper::busName, mapper::path,
+                                          mapper::interface, mapper::subtree);
+        method.append(std::string{"/"}, 0,
+                      std::vector<std::string>{powerStateInterface});
+        auto reply = bus.call(method);
+        reply.read(subtree);
+    }
+
+    auto entryIt = std::find_if(subtree.begin(), subtree.end(),
+                                [path](const auto& subtreeEntry) {
+        return path == subtreeEntry.first;
+    });
+    if (entryIt == subtree.end())
+    {
+        throw std::runtime_error("No power state interface on " + path);
+    }
+
+    const auto& services = entryIt->second;
+
+    auto method = bus.new_method_call(services[0].first.c_str(), path.c_str(),
+                                      properties::interface, properties::get);
+    method.append(powerStateInterface, "PowerState");
+
+    auto reply = bus.call(method);
+
+    std::variant<std::string> powerState;
+    reply.read(powerState);
+
+    return std::get<std::string>(powerState);
+}
+
+void SlotPowerManager::powerStateChanged(sdbusplus::message_t& msg)
+{
+    std::string objectPath = msg.get_path();
+    std::string interface;
+    std::map<std::string, std::variant<std::string>> properties;
+
+    msg.read(interface, properties);
+
+    auto propIt = properties.find("PowerState");
+    if (propIt == properties.end())
+    {
+        return;
+    }
+
+    if (!slotDevices.contains(objectPath))
+    {
+        // Don't care about this slot
+        return;
+    }
+
+    debug("Power state of {PATH} changed to {STATE}", "PATH", objectPath,
+          "STATE", std::get<std::string>(propIt->second));
+
+    const auto& powerState = std::get<std::string>(propIt->second);
+
+    // Update the state inside the config data.
+    auto& deviceConfigs = slotDevices.at(objectPath);
+    std::for_each(deviceConfigs.begin(), deviceConfigs.end(),
+                  [powerState](auto& config) { config.state = powerState; });
+
+    // Call slotOnFunc with the name of the sensor that changed
+    if (powerState.ends_with("On") && slotOnFunc)
+    {
+        auto sensors =
+            std::make_shared<boost::container::flat_set<std::string>>();
+
+        std::for_each(deviceConfigs.begin(), deviceConfigs.end(),
+                      [&sensors](const auto& config) {
+            // createSensors() doesn't want spaces
+            auto name = boost::replace_all_copy(config.name, " ", "_");
+            sensors->insert(name);
+        });
+        // Call createSensors() (which calls update())
+        slotOnFunc(sensors);
+    }
+}
+
+bool SlotPowerManager::isDeviceOff(const SensorBaseConfigMap& cfg) const
+{
+    auto findBus = cfg.find("Bus");
+    auto findAddr = cfg.find("Address");
+
+    if (findBus == cfg.end() || findAddr == cfg.end())
+    {
+        return false;
+    }
+
+    const uint64_t* bus = std::get_if<uint64_t>(&findBus->second);
+    const uint64_t* addr = std::get_if<uint64_t>(&findAddr->second);
+
+    if (bus == nullptr || addr == nullptr)
+    {
+        return false;
+    }
+    return isDeviceOff(*bus, *addr);
+}
+
+bool SlotPowerManager::isDeviceOff(uint64_t bus, uint64_t address) const
+{
+    for (const auto& [_, devices] : slotDevices)
+    {
+        auto deviceIt = std::find_if(devices.begin(), devices.end(),
+                                     [bus, address](const auto& device) {
+            return (bus == device.bus) && (address == device.address);
+        });
+
+        if (deviceIt != devices.end())
+        {
+            return deviceIt->state.ends_with("Off");
+        }
+    }
+    return false;
+}

--- a/src/SlotPowerManager.hpp
+++ b/src/SlotPowerManager.hpp
@@ -1,0 +1,84 @@
+#pragma once
+#include <Utils.hpp>
+#include <boost/container/flat_map.hpp>
+#include <boost/container/flat_set.hpp>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/bus/match.hpp>
+
+using SlotOnFuncType = std::function<void(
+    const std::shared_ptr<boost::container::flat_set<std::string>>&)>;
+
+static const char* powerStateInterface =
+    "xyz.openbmc_project.State.Decorator.PowerState";
+
+/**
+ * This class assists with handling sensor devices that are on the
+ * same power domain as the slot the card plugs into.
+ *
+ * It requires
+ *    "PowerStateOwner": "PCIeSlot",
+ *    "LocationCode": "<location code of slot>"
+ * in the entity-manager config to activate it for a device.
+ *
+ * public methods:
+ *   isDeviceOff()
+ *     - If the device is powered off or not based on the slot power state
+ *
+ *   update()
+ *     - Called from createSensors() to refresh the slot power status
+ *       so devices can be read if they are powered on.
+ *
+ * It also has propertiesChanged watches on the slot power states
+ * so it can call createSensors() again when slots are turned on so
+ * the sensor objects can be created.
+ */
+class SlotPowerManager
+{
+  public:
+    SlotPowerManager(sdbusplus::asio::connection& systemBus,
+                     SlotOnFuncType slotOnFunc) :
+        systemBus(systemBus),
+        match(static_cast<sdbusplus::bus::bus&>(systemBus),
+              "type='signal',member='PropertiesChanged',path_namespace='" +
+                  std::string(inventoryPath) + "',arg0namespace='" +
+                  powerStateInterface + "'",
+              [this](sdbusplus::message_t& msg) {
+        this->powerStateChanged(msg);
+    }),
+        slotOnFunc(std::move(slotOnFunc))
+    {}
+
+    bool isDeviceOff(uint64_t bus, uint64_t address) const;
+
+    bool isDeviceOff(const SensorBaseConfigMap& cfg) const;
+
+    void update(const ManagedObjectType& sensorConfigurations);
+
+  private:
+    struct DeviceInfo
+    {
+        std::string name;
+        std::string type;
+        std::string state;
+        std::string locationCode;
+        uint64_t bus{};
+        uint64_t address{};
+    };
+
+    void powerStateChanged(sdbusplus::message::message& msg);
+    static void getDeviceConfigs(const ManagedObjectType& sensorConfigurations,
+                                 std::vector<DeviceInfo>& deviceConfigs);
+    void getSlots(std::map<std::string, std::string>& slots);
+    std::string getPowerState(const std::string& path);
+
+    sdbusplus::asio::connection& systemBus;
+
+    sdbusplus::bus::match::match match;
+
+    std::map<std::string, std::vector<DeviceInfo>> slotDevices;
+
+    SlotOnFuncType slotOnFunc;
+};
+
+extern std::unique_ptr<SlotPowerManager> slotPowerManager;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -581,8 +581,11 @@ void createAssociation(
         fs::path p(path);
 
         std::vector<Association> associations;
-        associations.emplace_back("chassis", "all_sensors",
-                                  p.parent_path().string());
+        // Hardcode the chassis path until there is an upstream dbus-sensors
+        // way to find the appropriate chassis and not just the board.
+        associations.emplace_back(
+            "chassis", "all_sensors",
+            "/xyz/openbmc_project/inventory/system/chassis");
         association->register_property("Associations", associations);
         association->initialize();
     }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -42,10 +42,12 @@ static bool powerStatusOn = false;
 static bool biosHasPost = false;
 static bool manufacturingMode = false;
 static bool chassisStatusOn = false;
+static bool pgoodStatus = false;
 
 static std::unique_ptr<sdbusplus::bus::match_t> powerMatch = nullptr;
 static std::unique_ptr<sdbusplus::bus::match_t> postMatch = nullptr;
 static std::unique_ptr<sdbusplus::bus::match_t> chassisMatch = nullptr;
+static std::unique_ptr<sdbusplus::bus::match_t> pgoodMatch = nullptr;
 
 /**
  * return the contents of a file
@@ -291,6 +293,15 @@ bool isPowerOn(void)
     return powerStatusOn;
 }
 
+bool isPGoodOn()
+{
+    if (!pgoodMatch)
+    {
+        throw std::runtime_error("PGood Match Not Created");
+    }
+    return pgoodStatus;
+}
+
 bool hasBiosPost(void)
 {
     if (!postMatch)
@@ -306,7 +317,7 @@ bool isChassisOn(void)
     {
         throw std::runtime_error("Chassis On Match Not Created");
     }
-    return chassisStatusOn;
+    return chassisStatusOn && isPGoodOn();
 }
 
 bool readingStateGood(const PowerState& powerState)
@@ -357,6 +368,36 @@ static void
     },
         power::busname, power::path, properties::interface, properties::get,
         power::interface, power::property);
+}
+
+static void
+    getPGoodStatus(const std::shared_ptr<sdbusplus::asio::connection>& conn,
+                   size_t retries = 2)
+{
+    conn->async_method_call(
+        [conn, retries](boost::system::error_code ec,
+                        const std::variant<int>& pgoodValue) {
+        if (ec)
+        {
+            if (retries != 0U)
+            {
+                auto timer = std::make_shared<boost::asio::steady_timer>(
+                    conn->get_io_context());
+                timer->expires_after(std::chrono::seconds(15));
+                timer->async_wait(
+                    [timer, conn, retries](boost::system::error_code) {
+                    getPGoodStatus(conn, retries - 1);
+                });
+                return;
+            }
+
+            std::cerr << "error getting pgood status " << ec.message() << "\n";
+            return;
+        }
+        pgoodStatus = std::get<int>(pgoodValue) != 0;
+    },
+        pgood::busname, pgood::path, properties::interface, properties::get,
+        pgood::interface, pgood::property);
 }
 
 static void
@@ -541,9 +582,27 @@ void setupPowerMatchCallback(
             });
         }
     });
+
+    pgoodMatch = std::make_unique<sdbusplus::bus::match_t>(
+        static_cast<sdbusplus::bus_t&>(*conn),
+        "type='signal',interface='" + std::string(properties::interface) +
+            "',path='" + std::string(pgood::path) + "',arg0='" +
+            std::string(pgood::interface) + "'",
+        [](sdbusplus::message_t& message) {
+        std::string objectName;
+        boost::container::flat_map<std::string, std::variant<int>> values;
+        message.read(objectName, values);
+        auto findPGood = values.find(pgood::property);
+        if (findPGood != values.end())
+        {
+            pgoodStatus = std::get<int>(findPGood->second) != 0;
+        }
+    });
+
     getPowerStatus(conn);
     getPostStatus(conn);
     getChassisStatus(conn);
+    getPGoodStatus(conn);
 }
 
 void setupPowerMatch(const std::shared_ptr<sdbusplus::asio::connection>& conn)

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -71,6 +71,7 @@ bool findFiles(const std::filesystem::path& dirPath,
 bool isPowerOn(void);
 bool hasBiosPost(void);
 bool isChassisOn(void);
+bool isPGoodOn();
 void setupPowerMatchCallback(
     const std::shared_ptr<sdbusplus::asio::connection>& conn,
     std::function<void(PowerState type, bool state)>&& callback);
@@ -145,6 +146,14 @@ namespace association
 const static constexpr char* interface =
     "xyz.openbmc_project.Association.Definitions";
 } // namespace association
+
+namespace pgood
+{
+const static constexpr char* busname = "org.openbmc.control.Power";
+const static constexpr char* interface = "org.openbmc.control.Power";
+const static constexpr char* path = "/org/openbmc/control/power0";
+const static constexpr char* property = "pgood";
+} // namespace pgood
 
 template <typename T>
 inline T loadVariant(const SensorBaseConfigMap& data, const std::string& key)

--- a/src/meson.build
+++ b/src/meson.build
@@ -138,6 +138,7 @@ if get_option('hwmon-temp').allowed()
         'hwmontempsensor',
         'HwmonTempMain.cpp',
         'HwmonTempSensor.cpp',
+        'SlotPowerManager.cpp',
         dependencies: [
             default_deps,
             devicemgmt_dep,
@@ -211,6 +212,7 @@ if get_option('psu').allowed()
         'PSUEvent.cpp',
         'PSUSensor.cpp',
         'PSUSensorMain.cpp',
+        'SlotPowerManager.cpp',
         dependencies: [
             default_deps,
             devicemgmt_dep,

--- a/src/sensor.hpp
+++ b/src/sensor.hpp
@@ -250,6 +250,11 @@ struct Sensor
         return 1;
     }
 
+    virtual void createAssociation()
+    {
+        ::createAssociation(association, configurationPath);
+    }
+
     void setInitialProperties(const std::string& unit,
                               const std::string& label = std::string(),
                               size_t thresholdSize = 0)
@@ -260,7 +265,7 @@ struct Sensor
             setupPowerMatch(dbusConnection);
         }
 
-        createAssociation(association, configurationPath);
+        createAssociation();
 
         sensorInterface->register_property("Unit", unit);
         sensorInterface->register_property("MaxValue", maxValue);

--- a/src/sensor.hpp
+++ b/src/sensor.hpp
@@ -453,17 +453,18 @@ struct Sensor
         }
     }
 
-    void incrementError()
+    // Return true on the call that made the sensor go nonfunctional.
+    bool incrementError()
     {
         if (!readingStateGood())
         {
             markAvailable(false);
-            return;
+            return false;
         }
 
         if (errCount >= errorThreshold)
         {
-            return;
+            return false;
         }
 
         errCount++;
@@ -471,7 +472,9 @@ struct Sensor
         {
             std::cerr << "Sensor " << name << " reading error!\n";
             markFunctional(false);
+            return true;
         }
+        return false;
     }
 
     bool inError() const


### PR DESCRIPTION
These commits were all in 1060, I just pulled them into 1110.

They are for:

- Creating event logs for failing hwmontempsensor sensors
- Dealing with the tmp435 devices on cable cards
- adding inventory associations for PIM

Leaving off the downstream commit:
```
 nvmesensor: Disable use of io_uring
```
Maybe that has been fixed upstream by now.