### PR TITLE
Disable io_uring for hwmontempsensor

### DIFF
--- a/include/HwmonTempSensor.hpp
+++ b/include/HwmonTempSensor.hpp
@@ -2,7 +2,7 @@
 
 #include <DeviceMgmt.hpp>
 #include <Thresholds.hpp>
-#include <boost/asio/random_access_file.hpp>
+#include <boost/asio/streambuf.hpp>
 #include <sdbusplus/asio/object_server.hpp>
 #include <sensor.hpp>
 
@@ -53,13 +53,11 @@ class HwmonTempSensor :
     void createEventLog();
 
   private:
-    // Ordering is important here; readBuf is first so that it's not destroyed
-    // while async operations from other member fields might still be using it.
-    std::array<char, 128> readBuf{};
     std::shared_ptr<I2CDevice> i2cDevice;
     sdbusplus::asio::object_server& objServer;
-    boost::asio::random_access_file inputDev;
+    boost::asio::posix::stream_descriptor inputDev;
     boost::asio::steady_timer waitTimer;
+    boost::asio::streambuf readBuf;
     std::string path;
     double offsetValue;
     double scaleValue;
@@ -73,7 +71,7 @@ class HwmonTempSensor :
     // The error code from the last HW access for the sensor.
     boost::system::error_code errorCode;
 
-    void handleResponse(const boost::system::error_code& err, size_t bytesRead);
+    void handleResponse(const boost::system::error_code& err);
     void restartRead();
     void checkThresholds(void) override;
 };

--- a/src/meson.build
+++ b/src/meson.build
@@ -87,7 +87,6 @@ if get_option('hwmon-temp').enabled()
             thresholds_dep,
             utils_dep,
         ],
-        cpp_args: uring_args,
         implicit_include_directories: false,
         include_directories: '../include',
         install: true,


### PR DESCRIPTION
There have been a few cases where if hwmontempsensor is restarted right in the middle of an IPL, it fails to restart with:

```
    what():  io_uring_queue_init: Cannot allocate memory [system:12]",
```

io_uring is a kernel interface to do asynchronous files reads, and was introduced into hwmontempsensor as a performance improvement.

As IBM only monitors a handful of sensors, of which most a read at at least 1 seconds intervals, I'm just disabling io_uring by not passing in the compile flags to enable it.  This is also what shipped in 1020 and 1030 with no issues.

This also reverts another commit that requires io_uring.
