### PR TITLE
psusensor: add new CRPS185 power supply

### DIFF
--- a/src/PSUSensorMain.cpp
+++ b/src/PSUSensorMain.cpp
@@ -78,6 +78,7 @@ static const I2CDeviceTypeMap sensorTypes{
     {"cffps1", I2CDeviceType{"cffps", true}},
     {"cffps2", I2CDeviceType{"cffps", true}},
     {"cffps3", I2CDeviceType{"cffps", true}},
+    {"CRPS185", I2CDeviceType{"crps185", true}},
     {"DPS800", I2CDeviceType{"dps800", true}},
     {"INA219", I2CDeviceType{"ina219", true}},
     {"INA230", I2CDeviceType{"ina230", true}},


### PR DESCRIPTION
The CRPS185 is a new power supply for certain IBM systems. The device driver has been upstreamed in the Linux kernel.

Tested:
- Confirmed expected sensors appeared on dbus

Change-Id: I460fbf81f5f67f47f5dd56b9a1435f217b144f80

Upstream: https://gerrit.openbmc.org/c/openbmc/dbus-sensors/+/76431