### PR TITLE
Airpn v1 fix psu fan sensors

### DIFF
--- a/src/PSUSensorMain.cpp
+++ b/src/PSUSensorMain.cpp
@@ -51,6 +51,7 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <regex>
 #include <stdexcept>
@@ -672,14 +673,18 @@ static void createSensorsCallback(
                     continue;
                 }
             }
-
-            auto findProperty = labelMatch.find(sensorNameSubStr);
+            auto it = std::find_if(labelHead.begin(), labelHead.end(),
+                                   static_cast<int (*)(int)>(std::isdigit));
+            std::string_view labelHeadView(
+                labelHead.data(), std::distance(labelHead.begin(), it));
+            auto findProperty =
+                labelMatch.find(static_cast<std::string>(labelHeadView));
             if (findProperty == labelMatch.end())
             {
                 if constexpr (debug)
                 {
                     std::cerr << "Could not find matching default property for "
-                              << sensorNameSubStr << "\n";
+                              << labelHead << "\n";
                 }
                 continue;
             }

--- a/src/PSUSensorMain.cpp
+++ b/src/PSUSensorMain.cpp
@@ -644,6 +644,22 @@ static void createSensorsCallback(
                     labelHead.insert(0, "max");
                 }
 
+                // Don't add PWM sensors if it's not in label list
+                if (!findLabels.empty())
+                {
+                    /* Check if this labelHead is enabled in config file */
+                    if (std::find(findLabels.begin(), findLabels.end(),
+                                  labelHead) == findLabels.end())
+                    {
+                        if constexpr (debug)
+                        {
+                            lg2::error(
+                                "could not find {LABEL} in the Labels list",
+                                "LABEL", labelHead);
+                        }
+                        continue;
+                    }
+                }
                 checkPWMSensor(sensorPath, labelHead, *interfacePath,
                                dbusConnection, objectServer, psuNames[0]);
             }

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -263,12 +263,14 @@ struct GetSensorConfiguration :
                 const boost::system::error_code ec, SensorBaseConfigMap& data) {
                 if (ec)
                 {
-                    std::cerr << "Error getting " << path << ": retries left"
-                              << retries - 1 << "\n";
                     if (retries == 0U)
                     {
+                        std::cerr << "Error getting " << path
+                                  << ": no retries left\n";
                         return;
                     }
+                    std::cerr << "Error getting " << path << ": " << retries - 1
+                              << " retries left\n";
                     auto timer = std::make_shared<boost::asio::steady_timer>(
                         self->dbusConnection->get_io_context());
                     timer->expires_after(std::chrono::seconds(10));


### PR DESCRIPTION
This is a cherry pick of 2 upstream commits that improve logging and fix a bug with the PSU input sensors.

It also has one downstream commit to address a bug with the PSU fan sensors showing 0 on IBM System1. This last commit has been pushed upstream for review via https://gerrit.openbmc.org/c/openbmc/dbus-sensors/+/79379 but I'm not confident it's going to get very far as it's a bit hacky for our specific system.