### PR TITLE
utiilze cerr instead of lg2

### DIFF
--- a/src/PSUSensorMain.cpp
+++ b/src/PSUSensorMain.cpp
@@ -653,9 +653,8 @@ static void createSensorsCallback(
                     {
                         if constexpr (debug)
                         {
-                            lg2::error(
-                                "could not find {LABEL} in the Labels list",
-                                "LABEL", labelHead);
+                            std::cerr << "could not find " << labelHead
+                                      << " in the Labels list\n";
                         }
                         continue;
                     }


### PR DESCRIPTION
I cherry-picked a patch from upstream where the repo had moved over to using lg2. Our downstream snapshot though is stil using std::cerr. Use std::cerr.