### PR TITLE
hwmontemp: Clear thresholds if slot power off

### DIFF
--- a/src/ChassisIntrusionSensor.cpp
+++ b/src/ChassisIntrusionSensor.cpp
@@ -351,8 +351,7 @@ void ChassisIntrusionSensor::start()
 
 ChassisIntrusionSensor::ChassisIntrusionSensor(
     bool autoRearm, sdbusplus::asio::object_server& objServer) :
-    mValue(normalValStr),
-    mAutoRearm(autoRearm), mObjServer(objServer)
+    mValue(normalValStr), mAutoRearm(autoRearm), mObjServer(objServer)
 {
     mIface = mObjServer.add_interface("/xyz/openbmc_project/Chassis/Intrusion",
                                       "xyz.openbmc_project.Chassis.Intrusion");
@@ -361,8 +360,7 @@ ChassisIntrusionSensor::ChassisIntrusionSensor(
 ChassisIntrusionPchSensor::ChassisIntrusionPchSensor(
     bool autoRearm, boost::asio::io_context& io,
     sdbusplus::asio::object_server& objServer, int busId, int slaveAddr) :
-    ChassisIntrusionSensor(autoRearm, objServer),
-    mPollTimer(io)
+    ChassisIntrusionSensor(autoRearm, objServer), mPollTimer(io)
 {
     if (busId < 0 || slaveAddr <= 0)
     {
@@ -405,8 +403,8 @@ ChassisIntrusionPchSensor::ChassisIntrusionPchSensor(
 ChassisIntrusionGpioSensor::ChassisIntrusionGpioSensor(
     bool autoRearm, boost::asio::io_context& io,
     sdbusplus::asio::object_server& objServer, bool gpioInverted) :
-    ChassisIntrusionSensor(autoRearm, objServer),
-    mGpioInverted(gpioInverted), mGpioFd(io)
+    ChassisIntrusionSensor(autoRearm, objServer), mGpioInverted(gpioInverted),
+    mGpioFd(io)
 {
     mGpioLine = gpiod::find_line(mPinName);
     if (!mGpioLine)

--- a/src/DeviceMgmt.hpp
+++ b/src/DeviceMgmt.hpp
@@ -29,7 +29,7 @@ using I2CDeviceTypeMap =
 struct I2CDeviceParams
 {
     I2CDeviceParams(const I2CDeviceType& type, uint64_t bus, uint64_t address) :
-        type(&type), bus(bus), address(address){};
+        type(&type), bus(bus), address(address) {};
 
     const I2CDeviceType* type;
     uint64_t bus;

--- a/src/ExitAirTempSensor.cpp
+++ b/src/ExitAirTempSensor.cpp
@@ -140,8 +140,7 @@ static void setMaxPWM(const std::shared_ptr<sdbusplus::asio::connection>& conn,
                         std::cerr << "Error setting pid class\n";
                         return;
                     }
-                },
-                    owner, path, "org.freedesktop.DBus.Properties", "Set",
+                }, owner, path, "org.freedesktop.DBus.Properties", "Set",
                     pidConfigurationType, "OutLimitMax",
                     std::variant<double>(value));
             },
@@ -626,8 +625,7 @@ void ExitAirTempSensor::setupMatches(void)
                     properties::get, sensorValueInterface, "Value");
             }
         }
-    },
-        mapper::busName, mapper::path, mapper::interface, mapper::subtree,
+    }, mapper::busName, mapper::path, mapper::interface, mapper::subtree,
         "/xyz/openbmc_project/sensors/power", 0,
         std::array<const char*, 1>{sensorValueInterface});
 }

--- a/src/FileHandle.cpp
+++ b/src/FileHandle.cpp
@@ -17,7 +17,7 @@ FileHandle::FileHandle(const std::filesystem::path& name,
     }
 }
 
-FileHandle::FileHandle(int fdIn) : fd(fdIn){};
+FileHandle::FileHandle(int fdIn) : fd(fdIn) {};
 
 FileHandle::FileHandle(FileHandle&& in) noexcept : fd(in.fd)
 {

--- a/src/HwmonTempSensor.cpp
+++ b/src/HwmonTempSensor.cpp
@@ -128,6 +128,14 @@ void HwmonTempSensor::setupRead(void)
     {
         markAvailable(false);
         updateValue(std::numeric_limits<double>::quiet_NaN());
+        if (slotPowerManager->isDeviceOff(bus, address))
+        {
+            for (auto& threshold : thresholds)
+            {
+                assertThresholds(this, value, threshold.level,
+                                 threshold.direction, false);
+            }
+        }
         restartRead();
         return;
     }

--- a/src/HwmonTempSensor.cpp
+++ b/src/HwmonTempSensor.cpp
@@ -257,8 +257,7 @@ void HwmonTempSensor::createEventLog()
                       << name << "\n";
             return;
         }
-    },
-        "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
+    }, "xyz.openbmc_project.Logging", "/xyz/openbmc_project/logging",
         "xyz.openbmc_project.Logging.Create", "Create",
         "xyz.openbmc_project.Sensor.Device.Error.ReadFailure",
         "xyz.openbmc_project.Logging.Entry.Level.Error", additionalData);

--- a/src/IntelCPUSensorMain.cpp
+++ b/src/IntelCPUSensorMain.cpp
@@ -69,8 +69,7 @@ struct CPUConfig
 {
     CPUConfig(const uint64_t& bus, const uint64_t& addr,
               const std::string& name, const State& state) :
-        bus(bus),
-        addr(addr), name(name), state(state)
+        bus(bus), addr(addr), name(name), state(state)
     {}
     int bus;
     int addr;

--- a/src/IpmbSDRSensor.cpp
+++ b/src/IpmbSDRSensor.cpp
@@ -9,8 +9,7 @@ static constexpr uint8_t lun = 0;
 IpmbSDRDevice::IpmbSDRDevice(
     std::shared_ptr<sdbusplus::asio::connection>& dbusConnection,
     uint8_t cmdAddr) :
-    commandAddress(cmdAddr << 2),
-    hostIndex(cmdAddr + 1), conn(dbusConnection)
+    commandAddress(cmdAddr << 2), hostIndex(cmdAddr + 1), conn(dbusConnection)
 {}
 
 bool validateStatus(boost::system::error_code ec,

--- a/src/IpmbSensor.cpp
+++ b/src/IpmbSensor.cpp
@@ -597,8 +597,7 @@ void createSensors(
                 sensor->init();
             }
         }
-    },
-        entityManagerName, "/xyz/openbmc_project/inventory",
+    }, entityManagerName, "/xyz/openbmc_project/inventory",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
 }
 

--- a/src/PSUEvent.cpp
+++ b/src/PSUEvent.cpp
@@ -39,8 +39,7 @@ PSUCombineEvent::PSUCombineEvent(
     boost::asio::io_context& io, const std::string& psuName,
     const PowerState& powerState, EventPathList& eventPathList,
     GroupEventPathList& groupEventPathList, const std::string& combineEventName,
-    double pollRate) :
-    objServer(objectServer)
+    double pollRate) : objServer(objectServer)
 {
     std::string psuNameEscaped = sensor_paths::escapePathForDbus(psuName);
     eventInterface = objServer.add_interface(
@@ -140,10 +139,9 @@ PSUSubEvent::PSUSubEvent(
     std::shared_ptr<std::set<std::string>> asserts,
     std::shared_ptr<std::set<std::string>> combineEvent,
     std::shared_ptr<bool> state, const std::string& psuName, double pollRate) :
-    eventInterface(std::move(eventInterface)),
-    asserts(std::move(asserts)), combineEvent(std::move(combineEvent)),
-    assertState(std::move(state)), path(path), eventName(eventName),
-    readState(powerState), waitTimer(io),
+    eventInterface(std::move(eventInterface)), asserts(std::move(asserts)),
+    combineEvent(std::move(combineEvent)), assertState(std::move(state)),
+    path(path), eventName(eventName), readState(powerState), waitTimer(io),
 
     inputDev(io, path, boost::asio::random_access_file::read_only),
     psuName(psuName), groupEventName(groupEventName), systemBus(conn)

--- a/src/PSUSensor.hpp
+++ b/src/PSUSensor.hpp
@@ -69,9 +69,8 @@ class PSUProperty
   public:
     PSUProperty(std::string name, double max, double min, unsigned int factor,
                 double offset) :
-        labelTypeName(std::move(name)),
-        maxReading(max), minReading(min), sensorScaleFactor(factor),
-        sensorOffset(offset)
+        labelTypeName(std::move(name)), maxReading(max), minReading(min),
+        sensorScaleFactor(factor), sensorOffset(offset)
     {}
     ~PSUProperty() = default;
 

--- a/src/PwmSensor.cpp
+++ b/src/PwmSensor.cpp
@@ -35,8 +35,8 @@ PwmSensor::PwmSensor(const std::string& pwmname, const std::string& sysPath,
                      sdbusplus::asio::object_server& objectServer,
                      const std::string& sensorConfiguration,
                      const std::string& sensorType, bool isValueMutable) :
-    sysPath(sysPath),
-    objectServer(objectServer), name(sensor_paths::escapePathForDbus(pwmname))
+    sysPath(sysPath), objectServer(objectServer),
+    name(sensor_paths::escapePathForDbus(pwmname))
 {
     // add interface under sensor and Control.FanPwm as Control is used
     // in obmc project, also add sensor so it can be viewed as a sensor
@@ -60,9 +60,8 @@ PwmSensor::PwmSensor(const std::string& pwmname, const std::string& sysPath,
         setValue(pwmValue);
     }
     double fValue = 100.0 * (static_cast<double>(pwmValue) / pwmMax);
-    sensorInterface->register_property(
-        "Value", fValue,
-        [this](const double& req, double& resp) {
+    sensorInterface->register_property("Value", fValue,
+                                       [this](const double& req, double& resp) {
         if (!std::isfinite(req))
         {
             // Reject attempted change, if to NaN or other non-numeric
@@ -91,8 +90,7 @@ PwmSensor::PwmSensor(const std::string& pwmname, const std::string& sysPath,
         controlInterface->signal_property("Target");
 
         return 1;
-    },
-        [this](double& curVal) {
+    }, [this](double& curVal) {
         double currScaled = (curVal / 100.0) * pwmMax;
         auto currInt = static_cast<uint32_t>(std::round(currScaled));
         auto getInt = getValue();
@@ -134,8 +132,7 @@ PwmSensor::PwmSensor(const std::string& pwmname, const std::string& sysPath,
         sensorInterface->signal_property("Value");
 
         return 1;
-    },
-        [this](uint64_t& curVal) {
+    }, [this](uint64_t& curVal) {
         auto getInt = getValue();
         auto scaledValue = static_cast<double>(getInt) / pwmMax;
         auto roundValue = std::round(scaledValue * targetIfaceMax);

--- a/src/SlotPowerManager.hpp
+++ b/src/SlotPowerManager.hpp
@@ -44,8 +44,8 @@ class SlotPowerManager
                   std::string(inventoryPath) + "',arg0namespace='" +
                   powerStateInterface + "'",
               [this](sdbusplus::message_t& msg) {
-        this->powerStateChanged(msg);
-    }),
+                  this->powerStateChanged(msg);
+              }),
         slotOnFunc(std::move(slotOnFunc))
     {}
 

--- a/src/TachSensor.cpp
+++ b/src/TachSensor.cpp
@@ -212,8 +212,7 @@ void TachSensor::checkThresholds(void)
 PresenceSensor::PresenceSensor(const std::string& gpioName, bool inverted,
                                boost::asio::io_context& io,
                                const std::string& name) :
-    gpioLine(gpiod::find_line(gpioName)),
-    gpioFd(io), name(name)
+    gpioLine(gpiod::find_line(gpioName)), gpioFd(io), name(name)
 {
     if (!gpioLine)
     {
@@ -298,10 +297,9 @@ RedundancySensor::RedundancySensor(size_t count,
                                    const std::vector<std::string>& children,
                                    sdbusplus::asio::object_server& objectServer,
                                    const std::string& sensorConfiguration) :
-    count(count),
-    iface(objectServer.add_interface(
-        "/xyz/openbmc_project/control/FanRedundancy/Tach",
-        "xyz.openbmc_project.Control.FanRedundancy")),
+    count(count), iface(objectServer.add_interface(
+                      "/xyz/openbmc_project/control/FanRedundancy/Tach",
+                      "xyz.openbmc_project.Control.FanRedundancy")),
     association(objectServer.add_interface(
         "/xyz/openbmc_project/control/FanRedundancy/Tach",
         association::interface)),

--- a/src/Thresholds.cpp
+++ b/src/Thresholds.cpp
@@ -188,8 +188,7 @@ void persistThreshold(const std::string& path, const std::string& baseInterface,
                 {
                     std::cerr << "Error setting threshold " << ec << "\n";
                 }
-            },
-                entityManagerName, path, "org.freedesktop.DBus.Properties",
+            }, entityManagerName, path, "org.freedesktop.DBus.Properties",
                 "Set", thresholdInterface, "Value", value);
         },
             entityManagerName, path, "org.freedesktop.DBus.Properties",

--- a/src/Thresholds.hpp
+++ b/src/Thresholds.hpp
@@ -36,8 +36,8 @@ struct Threshold
         const Level& lev, const Direction& dir, const double& val,
         const double hysteresis = std::numeric_limits<double>::quiet_NaN(),
         bool write = true) :
-        level(lev),
-        direction(dir), value(val), hysteresis(hysteresis), writeable(write)
+        level(lev), direction(dir), value(val), hysteresis(hysteresis),
+        writeable(write)
     {}
     Level level;
     Direction direction;

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -239,8 +239,7 @@ inline void setLed(const std::shared_ptr<sdbusplus::asio::connection>& conn,
         {
             std::cerr << "Failed to set LED " << name << "\n";
         }
-    },
-        "xyz.openbmc_project.LED.GroupManager",
+    }, "xyz.openbmc_project.LED.GroupManager",
         "/xyz/openbmc_project/led/groups/" + name, properties::interface,
         properties::set, "xyz.openbmc_project.Led.Group", "Asserted",
         std::variant<bool>(on));
@@ -257,8 +256,7 @@ struct GetSensorConfiguration :
     GetSensorConfiguration(
         std::shared_ptr<sdbusplus::asio::connection> connection,
         std::function<void(ManagedObjectType& resp)>&& callbackFunc) :
-        dbusConnection(std::move(connection)),
-        callback(std::move(callbackFunc))
+        dbusConnection(std::move(connection)), callback(std::move(callbackFunc))
     {}
 
     void getPath(const std::string& path, const std::string& interface,


### PR DESCRIPTION
If a sensor on slot power was powered off when a threshold alarm property was asserted, it was not getting cleared.

To fix this, explicitly clear the thresholds when sensor's slot is off.

This is similar to the code that already runs in Sensor::updateValue() that is already handling clearing thresholds when a sensor is on host or chassis power and it is powered off. It looks like:

```
if (!readingStateGood())
{
    markAvailable(false);
    for (auto& threshold : thresholds)
    {
        assertThresholds(this, value, threshold.level,
                            threshold.direction, false);
    }
    ...
}

```

I didn't want to bring slotPowerManager into the Sensor class as that is shared between all sensor daemons, and slot power management is downstream only and I want to keep its footprint as small as possible.

Tested:

Before, the threshold alarm was true even after the slot was powered off and the sensor value was nan:
```
xyz.openbmc_project.Sensor.Threshold.Warning          interface
.WarningAlarmHigh                                     property  b         true

xyz.openbmc_project.Sensor.Value                      interface
.Value                                                property  d         nan
```

After, the alarm property is now false:
```
xyz.openbmc_project.Sensor.Threshold.Warning          interface
.WarningAlarmHigh                                     property  b         false

xyz.openbmc_project.Sensor.Value                   interface
.Value                                                property  d         nan
```