### PR TITLE
1120: hwmontemp: Clear thresholds if slot power off

### DIFF
--- a/src/hwmon-temp/HwmonTempSensor.cpp
+++ b/src/hwmon-temp/HwmonTempSensor.cpp
@@ -146,6 +146,14 @@ void HwmonTempSensor::setupRead()
     {
         markAvailable(false);
         updateValue(std::numeric_limits<double>::quiet_NaN());
+        if (slotPowerManager->isDeviceOff(bus, address))
+        {
+            for (auto& threshold : thresholds)
+            {
+                assertThresholds(this, value, threshold.level,
+                                 threshold.direction, false);
+            }
+        }
         restartRead();
         return;
     }


### PR DESCRIPTION
#### hwmontemp: Clear thresholds if slot power off
```
If a sensor on slot power was powered off when a threshold alarm
property was asserted, it was not getting cleared.

To fix this, explicitly clear the thresholds when sensor's slot is off.

This is similar to the code that already runs in Sensor::updateValue()
that is already handling clearing thresholds when a sensor is on host or
chassis power and it is powered off. It looks like:

```
if (!readingStateGood())
{
    markAvailable(false);
    for (auto& threshold : thresholds)
    {
        assertThresholds(this, value, threshold.level,
                            threshold.direction, false);
    }
    ...
}

```

I didn't want to bring slotPowerManager into the Sensor class as that is
shared between all sensor daemons, and slot power management is
downstream only and I want to keep its footprint as small as possible.

Tested:

Before, the threshold alarm was true even after the slot was
powered off and the sensor value was nan:
```
xyz.openbmc_project.Sensor.Threshold.Warning          interface
.WarningAlarmHigh                                     property  b         true

xyz.openbmc_project.Sensor.Value                      interface
.Value                                                property  d         nan
```

After, the alarm property is now false:
```
xyz.openbmc_project.Sensor.Threshold.Warning          interface
.WarningAlarmHigh                                     property  b         false

xyz.openbmc_project.Sensor.Value                   interface
.Value                                                property  d         nan
```

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
```