### PR TITLE
Revert "Hardcode the chassis association path" & comment out createAssociation

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -659,16 +659,15 @@ void findLimits(std::pair<double, double>& limits,
 
 void createAssociation(
     std::shared_ptr<sdbusplus::asio::dbus_interface>& association,
-    [[maybe_unused]] const std::string& path)
+    const std::string& path)
 {
     if (association)
     {
+        std::filesystem::path p(path);
+
         std::vector<Association> associations;
-        // Hardcode the chassis path until there is an upstream dbus-sensors
-        // way to find the appropriate chassis and not just the board.
-        associations.emplace_back(
-            "chassis", "all_sensors",
-            "/xyz/openbmc_project/inventory/system/chassis");
+        associations.emplace_back("chassis", "all_sensors",
+                                  p.parent_path().string());
         association->register_property("Associations", associations);
         association->initialize();
     }

--- a/src/sensor.hpp
+++ b/src/sensor.hpp
@@ -274,7 +274,7 @@ struct Sensor
             setupPowerMatch(dbusConnection);
         }
 
-        createAssociation();
+        // createAssociation();
 
         sensorInterface->register_property("Unit", unit);
         sensorInterface->register_property("MaxValue", maxValue);


### PR DESCRIPTION
Revert the hardcode from 28cc05a which set the chassis association to /xyz/openbmc_project/inventory/system/chassis. This path has no Item.Chassis interface on Huygens, causing ambient sensors to not appear in Redfish. This may pose a problem with future multi-chassis systems.

Comment out the createAssociation call in sensor.hpp pending a proper fix that uses dynamic chassis discovery.